### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/ecmech/ECMech_evptn.h
+++ b/src/ecmech/ECMech_evptn.h
@@ -65,8 +65,7 @@ namespace ecmech {
                _c12 = *parsIt; ++parsIt;
                _c44 = *parsIt; ++parsIt;
                //
-               int iParam = parsIt - params.begin();
-               assert(iParam == nParams);
+               assert((parsIt - params.begin()) == nParams);
 
                _K_diag[0] = _c11 - _c12;
                _K_diag[1] = _c11 - _c12;
@@ -81,15 +80,18 @@ namespace ecmech {
             __ecmech_host__
             inline void getParams(std::vector<double> & params
                                   ) const {
+#ifdef ECMECH_DEBUG
                // do not clear params in case adding to an existing set
                int paramsStart = params.size();
+#endif
 
                params.push_back(_c11);
                params.push_back(_c12);
                params.push_back(_c44);
 
-               int iParam = params.size() - paramsStart;
-               assert(iParam == nParams);
+#ifdef ECMECH_DEBUG
+               assert((params.size() - paramsStart) == nParams);
+#endif
             }
 
             __ecmech_hdev__
@@ -250,8 +252,7 @@ namespace ecmech {
                //
                _g_vecd2 = *parsIt; ++parsIt;
                //
-               int iParam = parsIt - params.begin();
-               assert(iParam == nParams);
+               assert((parsIt - params.begin()) == nParams);
 
                _K_diag[0] = _c11 - _c12;
                _K_diag[1] = _c11 * onethird + _c12 * onethird - fourthirds * _c13 + twothird * _c33;
@@ -269,8 +270,10 @@ namespace ecmech {
             __ecmech_host__
             inline void getParams(std::vector<double> & params
                                   ) const {
+#ifdef ECMECH_DEBUG
                // do not clear params in case adding to an existing set
                int paramsStart = params.size();
+#endif
 
                params.push_back(_c11);
                params.push_back(_c12);
@@ -280,8 +283,9 @@ namespace ecmech {
                //
                params.push_back(_g_vecd2);
 
-               int iParam = params.size() - paramsStart;
-               assert(iParam == nParams);
+#ifdef ECMECH_DEBUG
+               assert((params.size() - paramsStart) == nParams);
+#endif
             }
 
             __ecmech_hdev__

--- a/src/ecmech/ECMech_kinetics_KMBalD.h
+++ b/src/ecmech/ECMech_kinetics_KMBalD.h
@@ -130,15 +130,16 @@ namespace ecmech {
 
             //////////////////////////////
 
-            int iParam = parsIt - params.begin();
-            assert(iParam == nParams);
+            assert((parsIt - params.begin()) == nParams);
          };
 
          __ecmech_host__
          void getParams(std::vector<double> & params
                         ) const {
+#ifdef ECMECH_DEBUG
             // do not clear params in case adding to an existing set
             int paramsStart = params.size();
+#endif
 
             //////////////////////////////
             // power-law stuff
@@ -177,9 +178,9 @@ namespace ecmech {
             params.push_back(_hdn_init);
 
             //////////////////////////////
-
-            int iParam = params.size() - paramsStart;
-            assert(iParam == nParams);
+#ifdef ECMECH_DEBUG
+            assert((params.size() - paramsStart) == nParams);
+#endif
          };
 
          __ecmech_host__

--- a/src/ecmech/ECMech_kinetics_VocePL.h
+++ b/src/ecmech/ECMech_kinetics_VocePL.h
@@ -74,15 +74,16 @@ namespace ecmech {
 
             //////////////////////////////
 
-            int iParam = parsIt - params.begin();
-            assert(iParam == nParams);
+            assert((parsIt - params.begin()) == nParams);
          }
 
          __ecmech_host__
          inline void getParams(std::vector<double> & params
                                ) const {
+#ifdef ECMECH_DEBUG
             // do not clear params in case adding to an existing set
             int paramsStart = params.size();
+#endif
 
             //////////////////////////////
             // power-law stuff
@@ -107,8 +108,9 @@ namespace ecmech {
 
             //////////////////////////////
 
-            int iParam = params.size() - paramsStart;
-            assert(iParam == nParams);
+#ifdef ECMECH_DEBUG            
+            assert((params.size() - paramsStart) == nParams);
+#endif
          }
 
          __ecmech_host__

--- a/src/ecmech/ECMech_slipgeom.h
+++ b/src/ecmech/ECMech_slipgeom.h
@@ -61,7 +61,6 @@ namespace ecmech {
          void setParams(const std::vector<double> & /* params */
                         )
          {
-            // std::vector<double>::const_iterator parsIt = params.begin();
 
             // m = (/ sqr3i, sqr3i, sqr3i /)
             // s = (/ zero, sqr2i, -sqr2i /)
@@ -98,19 +97,12 @@ namespace ecmech {
 
             fillFromMS(this->_P_ref_vec, this->_Q_ref_vec,
                        mVecs, sVecs, this->nslip);
-
-            // assert((parsIt - params.begin()) == nParams);
          };
 
          __ecmech_host__
          void getParams(std::vector<double> & /* params */
                         ) const {
             // do not clear params in case adding to an existing set
-            // int paramsStart = params.size();
-
-            // params.push_back(); // no parameters
-
-            // assert((params.size() - paramsStart) == nParams);
          }
 
          __ecmech_hdev__ inline const double* getP() const { return _P_ref_vec; };
@@ -152,7 +144,6 @@ namespace ecmech {
          void setParams(const std::vector<double> & /* params */
                         )
          {
-            // std::vector<double>::const_iterator parsIt = params.begin();
 
             std::vector<double> mVecs;
             std::vector<double> sVecs;
@@ -299,19 +290,12 @@ namespace ecmech {
             
             fillFromMS(this->_P_ref_vec, this->_Q_ref_vec,
                        &(mVecs[0]), &(sVecs[0]), this->nslip);
-
-            // assert((parsIt - params.begin()) == nParams);
          };
 
          __ecmech_host__
          void getParams(std::vector<double> & /* params */
                         ) const {
             // do not clear params in case adding to an existing set
-            // int paramsStart = params.size();
-
-            // params.push_back(); // no parameters
-
-            // assert((params.size() - paramsStart) == nParams);
          }
 
          __ecmech_hdev__ inline const double* getP() const { return _P_ref_vec; };

--- a/src/ecmech/ECMech_slipgeom.h
+++ b/src/ecmech/ECMech_slipgeom.h
@@ -58,10 +58,10 @@ namespace ecmech {
          __ecmech_hdev__ ~SlipGeomFCC() {};
 
          __ecmech_host__
-         void setParams(const std::vector<double> & params
+         void setParams(const std::vector<double> & /* params */
                         )
          {
-            std::vector<double>::const_iterator parsIt = params.begin();
+            // std::vector<double>::const_iterator parsIt = params.begin();
 
             // m = (/ sqr3i, sqr3i, sqr3i /)
             // s = (/ zero, sqr2i, -sqr2i /)
@@ -99,20 +99,18 @@ namespace ecmech {
             fillFromMS(this->_P_ref_vec, this->_Q_ref_vec,
                        mVecs, sVecs, this->nslip);
 
-            int iParam = parsIt - params.begin();
-            assert(iParam == nParams);
+            // assert((parsIt - params.begin()) == nParams);
          };
 
          __ecmech_host__
-         void getParams(std::vector<double> & params
+         void getParams(std::vector<double> & /* params */
                         ) const {
             // do not clear params in case adding to an existing set
-            int paramsStart = params.size();
+            // int paramsStart = params.size();
 
             // params.push_back(); // no parameters
 
-            int iParam = params.size() - paramsStart;
-            assert(iParam == nParams);
+            // assert((params.size() - paramsStart) == nParams);
          }
 
          __ecmech_hdev__ inline const double* getP() const { return _P_ref_vec; };
@@ -151,10 +149,10 @@ namespace ecmech {
          __ecmech_hdev__ ~SlipGeomBCC() {};
 
          __ecmech_host__
-         void setParams(const std::vector<double> & params
+         void setParams(const std::vector<double> & /* params */
                         )
          {
-            std::vector<double>::const_iterator parsIt = params.begin();
+            // std::vector<double>::const_iterator parsIt = params.begin();
 
             std::vector<double> mVecs;
             std::vector<double> sVecs;
@@ -302,20 +300,18 @@ namespace ecmech {
             fillFromMS(this->_P_ref_vec, this->_Q_ref_vec,
                        &(mVecs[0]), &(sVecs[0]), this->nslip);
 
-            int iParam = parsIt - params.begin();
-            assert(iParam == nParams);
+            // assert((parsIt - params.begin()) == nParams);
          };
 
          __ecmech_host__
-         void getParams(std::vector<double> & params
+         void getParams(std::vector<double> & /* params */
                         ) const {
             // do not clear params in case adding to an existing set
-            int paramsStart = params.size();
+            // int paramsStart = params.size();
 
             // params.push_back(); // no parameters
 
-            int iParam = params.size() - paramsStart;
-            assert(iParam == nParams);
+            // assert((params.size() - paramsStart) == nParams);
          }
 
          __ecmech_hdev__ inline const double* getP() const { return _P_ref_vec; };
@@ -447,20 +443,22 @@ namespace ecmech {
             fillFromMS(this->_P_ref_vec, this->_Q_ref_vec,
                        mVecs, sVecs, this->nslip);
 
-            int iParam = parsIt - params.begin();
-            assert(iParam == nParams);
+            assert((parsIt - params.begin()) == nParams);
          };
 
          __ecmech_host__
          void getParams(std::vector<double> & params
                         ) const {
+#ifdef ECMECH_DEBUG
             // do not clear params in case adding to an existing set
             int paramsStart = params.size();
+#endif
 
             params.push_back(_cOverA);
 
-            int iParam = params.size() - paramsStart;
-            assert(iParam == nParams);
+#ifdef ECMECH_DEBUG
+            assert((params.size() - paramsStart) == nParams);
+#endif
          }
 
          __ecmech_hdev__ inline const double* getP() const { return _P_ref_vec; };

--- a/test/test_aniso_kinetics_VocePL.h
+++ b/test/test_aniso_kinetics_VocePL.h
@@ -27,7 +27,7 @@ namespace ecmech {
 
          // constructor
          __ecmech_hdev__
-         KineticsAnisoVocePL(int nslip_) {};
+         KineticsAnisoVocePL(int /* nslip_ */) {};
          // deconstructor
          __ecmech_hdev__
          ~KineticsAnisoVocePL() {}
@@ -82,15 +82,16 @@ namespace ecmech {
 
             //////////////////////////////
 
-            int iParam = parsIt - params.begin();
-            assert(iParam == nParams);
+            assert((parsIt - params.begin()) == nParams);
          }
 
          __ecmech_host__
          inline void getParams(std::vector<double> & params
                                ) const {
+#ifdef ECMECH_DEBUG
             // do not clear params in case adding to an existing set
             int paramsStart = params.size();
+#endif
 
             //////////////////////////////
             // power-law stuff
@@ -116,9 +117,9 @@ namespace ecmech {
             params.push_back(_hdn_init);
 
             //////////////////////////////
-
-            int iParam = params.size() - paramsStart;
-            assert(iParam == nParams);
+#ifdef ECMECH_DEBUG
+            assert((params.size() - paramsStart) == nParams);
+#endif
          }
 
          __ecmech_host__


### PR DESCRIPTION
This closes #8 and fixes all of the compiler warnings that we were seeing in regards to unused variables in release mode.