### PR TITLE
[Bugfix] Config file not correctly get set in fresh builds

### DIFF
--- a/cmake/CMakeBasics.cmake
+++ b/cmake/CMakeBasics.cmake
@@ -15,11 +15,22 @@ set(HEADER_INCLUDE_DIR
 ################################
 # Setup build options and their default values
 ################################
+
 include(cmake/ECMechOptions.cmake)
 
 ##############################
 # settings into ECMech_config.h
 ##############################
+
+set(HAVE_ECMECH "1" CACHE STRING "")
+
+if(USE_DPEFF)
+    set(ECMECH_USE_DPEFF "1" CACHE STRING "")
+endif()
+
+if(CMAKE_BUILD_TYPE MATCHES DEBUG)
+    set(ECMECH_DEBUG "1" CACHE STRING "")
+endif()
 
 configure_file( src/ecmech/ECMech_config.h.in
                 ${HEADER_INCLUDE_DIR}/ECMech_config.h )

--- a/src/ecmech/CMakeLists.txt
+++ b/src/ecmech/CMakeLists.txt
@@ -43,16 +43,6 @@ message("-- ECMECH_DEPENDS: ${ECMECH_DEPENDS}")
 #------------------------------------------------------------------------------
 set(ECMECH_DEFINES)
 
-set(HAVE_ECMECH "1" CACHE STRING "")
-
-if(USE_DPEFF)
-    set(ECMECH_USE_DPEFF "1" CACHE STRING "")
-endif()
-
-if(CMAKE_BUILD_TYPE MATCHES DEBUG)
-    set(ECMECH_DEBUG "1" CACHE STRING "")
-endif()
-
 #------------------------------------------------------------------------------
 # Includes
 #------------------------------------------------------------------------------


### PR DESCRIPTION
The defines for the config file were too late in the cmake process and so the config file was not correctly getting set.

I hadn't noticed this problem in #13 simply because I usually wasn't doing fresh builds of the whole project so everything was usually already set.