### PR TITLE
Python bindings for ECMech

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 build*/
 install*/
+*.cpython*
+.vscode*/

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = snls
 	url = https://github.com/LLNL/SNLS.git
 	branch = develop
+[submodule "pybind11"]
+	path = pybind11
+	url = https://github.com/pybind/pybind11.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,3 +99,32 @@ endif(ENABLE_TESTS)
 if(ENABLE_MINIAPPS)
     add_subdirectory(miniapp)
 endif(ENABLE_MINIAPPS)
+
+if(ENABLE_PYTHON)
+
+################################
+# PYBIND11
+################################
+    set(USE_BUILT_PYBIND OFF CACHE BOOL "")
+
+    set(PYBIND_SOURCE_DIR "${PROJECT_SOURCE_DIR}/pybind11" CACHE PATH "")
+    message(STATUS "Using submodule PYBIND11: ${PYBIND_SOURCE_DIR}")
+    if (NOT EXISTS ${PYBIND_SOURCE_DIR}/CMakeLists.txt)
+        message(FATAL_ERROR
+            "The pybind11 submodule is not present. "
+            "Run the following two commands in your git repository: \n"
+            "    git submodule init\n"
+            "    git submodule update\n"
+            "Or you can point to an already built pybind11 with PYBIND_DIR." )
+    endif()
+
+    add_subdirectory(pybind11)
+
+    # If using internal submodule use actual CMake targets
+    set(PYBIND_SHARED_TARGET pybind11 CACHE STRING "")
+    set(PYBIND_STATIC_TARGET pybind11 CACHE STRING "")
+##########################################
+# Python bindings of models
+##########################################
+    add_subdirectory(pyecmech/)
+endif()

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ A miniapp is provided which provides a guide for how the library might be used i
 
 If all of the features are used it can be built with the following commands when used on a CORAL architecture: `cmake ../ -DCMAKE_INSTALL_PREFIX=../install_dir/ -DRAJA_DIR={$RAJA_PATH}/raja/install_dir/share/raja/cmake/ -DENABLE_OPENMP=ON -DENABLE_CUDA=ON -DCUDA_ARCH=sm_70 -DENABLE_TESTS=ON -DENABLE_MINIAPPS=ON -DCMAKE_BUILD_TYPE=Release`
 
+PYTHON
+======
+
+A limited set of python bindings are now available that enable one to run `getResponseECM` like calculations from within python through the `pyECMech` class. One can look at the `pyecmech/example.py` as an example of how to use these bindings to run material point simulations. In order to enable these bindings, one has to run cmake with `-DENABLE_PYTHON=ON`. 
+
+If one is more interested in development work from within python they can add the additional cmake define `-DENABLE_PYTHON_DEV=ON`. This cmake define introduces a new python class called `pyECMechDev` which allows users access to the internals of `getResponseECM`. The intended use of this class is currently to allow developers to play around with different solvers for the nonlinear set of equations being solved within ExaCMech. One can look at `pyecmech/example-dev.py` as an example of how to use these bindings to run material point simulations.
+
 AUTHORS
 ======
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ If all of the features are used it can be built with the following commands when
 PYTHON
 ======
 
-A limited set of python bindings are now available that enable one to run `getResponseECM` like calculations from within python through the `pyECMech` class. One can look at the `pyecmech/example.py` as an example of how to use these bindings to run material point simulations. In order to enable these bindings, one has to run cmake with `-DENABLE_PYTHON=ON`. 
+An initial set of pythons bindings are now available to users. These bindings allow one to run material point simulation like calculations from within python through the `pyECMech` class. One can look at `pyecmech/example.py` as an example for how to use these bindings. In order to enable these bindings, one has to run cmake with `-DENABLE_PYTHON=ON`. 
 
-If one is more interested in development work from within python they can add the additional cmake define `-DENABLE_PYTHON_DEV=ON`. This cmake define introduces a new python class called `pyECMechDev` which allows users access to the internals of `getResponseECM`. The intended use of this class is currently to allow developers to play around with different solvers for the nonlinear set of equations being solved within ExaCMech. One can look at `pyecmech/example-dev.py` as an example of how to use these bindings to run material point simulations.
+If one is more interested in development work from within python they can add the additional cmake define `-DENABLE_PYTHON_DEV=ON`. This cmake define introduces a new python class called `pyECMechDev` which allows developers access to the internals of `getResponseECM`. The intended use of this class is currently to allow developers to play around with different solvers for the nonlinear set of equations being solved within ExaCMech. One can look at `pyecmech/example-dev.py` as an example of how to use these bindings to run material point simulations.
 
 AUTHORS
 ======

--- a/cmake/CMakeBasics.cmake
+++ b/cmake/CMakeBasics.cmake
@@ -28,6 +28,14 @@ if(USE_DPEFF)
     set(ECMECH_USE_DPEFF "1" CACHE STRING "")
 endif()
 
+if(ENABLE_PYTHON)
+    set(ECMECH_PY "1" CACHE STRING "")
+endif()
+
+if(ENABLE_PYTHON_DEV)
+    set(ECMECH_PYDEV "1" CACHE STRING "")
+endif()
+
 if(CMAKE_BUILD_TYPE MATCHES DEBUG)
     set(ECMECH_DEBUG "1" CACHE STRING "")
 endif()

--- a/cmake/ECMechOptions.cmake
+++ b/cmake/ECMechOptions.cmake
@@ -17,6 +17,8 @@ option(ENABLE_OPENMP "Enable openmp" ON)
 
 option(ENABLE_MINIAPPS "Enable miniapps" ON)
 
+option(ENABLE_PYTHON "Enable building of python bindings" ON)
+
 # Force atleast static if user turns off both
 if(NOT BUILD_STATIC_LIBS AND NOT BUILD_SHARED_LIBS)
     message("Both static and shared libaries were disabled."

--- a/cmake/ECMechOptions.cmake
+++ b/cmake/ECMechOptions.cmake
@@ -17,7 +17,9 @@ option(ENABLE_OPENMP "Enable openmp" ON)
 
 option(ENABLE_MINIAPPS "Enable miniapps" ON)
 
-option(ENABLE_PYTHON "Enable building of python bindings" ON)
+option(ENABLE_PYTHON "Enable building of python bindings" OFF)
+
+option(ENABLE_PYTHON_DEV "Enable building of python dev bindings" OFF)
 
 # Force atleast static if user turns off both
 if(NOT BUILD_STATIC_LIBS AND NOT BUILD_SHARED_LIBS)

--- a/pyecmech/CMakeLists.txt
+++ b/pyecmech/CMakeLists.txt
@@ -1,10 +1,12 @@
 #include(${PYBIND_SOURCE_DIR}/CMakeLists.txt)
 
-pybind11_add_module(ecmech ./ecmech_pybind11.cpp ./ecmechpy.cpp)
-target_include_directories(ecmech SYSTEM PUBLIC ${ECMECH_HEADERS})
+pybind11_add_module(pyecmech ./ecmech_pybind11.cpp ./ecmechpy.cpp)
+target_include_directories(pyecmech SYSTEM PUBLIC ${ECMECH_HEADERS})
 
-target_link_libraries(ecmech PUBLIC ecmech_static PRIVATE )
+target_link_libraries(pyecmech PUBLIC ecmech_static PRIVATE )
 
 if(ENABLE_OPENMP)
-    target_link_libraries(ecmech PRIVATE OpenMP::OpenMP_CXX)
+    target_link_libraries(pyecmech PRIVATE OpenMP::OpenMP_CXX)
 endif()
+
+install(TARGETS pyecmech DESTINATION python)

--- a/pyecmech/CMakeLists.txt
+++ b/pyecmech/CMakeLists.txt
@@ -1,0 +1,10 @@
+#include(${PYBIND_SOURCE_DIR}/CMakeLists.txt)
+
+pybind11_add_module(ecmech ./ecmech_pybind11.cpp ./ecmechpy.cpp ./ecmech_classes.cpp)
+target_include_directories(ecmech SYSTEM PUBLIC ${ECMECH_HEADERS})
+
+target_link_libraries(ecmech PUBLIC ecmech_static PRIVATE )
+
+if(ENABLE_OPENMP)
+    target_link_libraries(ecmech PRIVATE OpenMP::OpenMP_CXX)
+endif()

--- a/pyecmech/CMakeLists.txt
+++ b/pyecmech/CMakeLists.txt
@@ -1,6 +1,6 @@
 #include(${PYBIND_SOURCE_DIR}/CMakeLists.txt)
 
-pybind11_add_module(ecmech ./ecmech_pybind11.cpp ./ecmechpy.cpp ./ecmech_classes.cpp)
+pybind11_add_module(ecmech ./ecmech_pybind11.cpp ./ecmechpy.cpp)
 target_include_directories(ecmech SYSTEM PUBLIC ${ECMECH_HEADERS})
 
 target_link_libraries(ecmech PUBLIC ecmech_static PRIVATE )

--- a/pyecmech/ecmech_classes.hpp
+++ b/pyecmech/ecmech_classes.hpp
@@ -1,0 +1,429 @@
+#ifndef ECMECH_CLASSES_HPP
+#define ECMECH_CLASSES_HPP
+
+#include "ECMech_const.h"
+#include "ECMech_core.h"
+#include "ECMech_cases.h"
+
+class pyevptn_base
+{
+    public:
+    pyevptn_base(std::vector<double> &/*params*/) {}
+    virtual ~pyevptn_base() {}
+    /// Provides history names, initial values, 
+    /// whether the param is meant to be plotted,
+    /// and whether its a state variable
+    void getHistoryInfo(std::vector<std::string> names,
+                        std::vector<double>vals,
+                        std::vector<bool> plot,
+                        std::vector<bool> state)
+    {
+        const int numHist = m_rhvNames.size();
+        names.resize(numHist); std::copy(m_rhvNames.begin(), m_rhvNames.end(), names.begin() );
+        vals.resize(numHist); std::copy(m_rhvVals.begin(), m_rhvVals.end(), vals.begin() );
+        plot.resize(numHist); std::copy(m_rhvPlot.begin(), m_rhvPlot.end(), plot.begin() );
+        state.resize(numHist); std::copy(m_rhvState.begin(), m_rhvState.end(), state.begin() );
+    };
+    /// Should be called each time step and point to set-up problem
+    virtual void setup( double    dt,
+                        double    tolerance,
+                        const double  * d_svec_kk_sm, // defRate,
+                        const double  * w_veccp_sm, // spin
+                        const double  * volRatio,
+                        double  * eInt,
+                        double  * stressSvecP,
+                        double  * hist,
+                        double  & tkelv,
+                        double  * sdd,
+                        double  * mtanSD,
+                        int outputLevel = 0) = 0;
+    /// Should be handed to nonlinear solver for each time step and point
+    /// for the Jacobian/gradient and function calculations
+    virtual void computeRJ(double * const resid,
+                           double * const Jacobian,
+                           const double * const x) = 0;
+    /// Should be called after a nonlinear solve for each time step and point
+    /// to get out the state at end of each time step for a material point
+    virtual void getState(const double * const x,
+                          double * const eInt,
+                          double * const stressSvecP,
+                          double * const hist,
+                          double& tkelv,
+                          double * const sdd) = 0;
+    protected:
+
+    // Variables related to history names and their initial values
+    std::vector<std::string> m_rhvNames;
+    std::vector<double> m_rhvVals;
+    std::vector<bool> m_rhvPlot;
+    std::vector<bool> m_rhvState;
+
+    // Various variables needed in set-up phases
+    double m_dt;
+    double m_tolerance;
+    double m_d_svec_kk_sm[ecmech::nsvp]; // defRate,
+    double m_w_veccp_sm[ecmech::nwvec]; // spin
+    double m_volRatio[ecmech::nvr];
+    double m_eInt[ecmech::ne];
+    double m_stressSvecP[ecmech::nsvp];
+    double m_quat_n[ecmech::qdim];
+    double m_tkelv;
+    double m_vNew;
+    double m_pEOS;
+    double m_d_vecd_sm[ecmech::ntvec];
+    double m_e_vecd_n[ecmech::ntvec];
+    double m_eNew;
+    double m_eDevTot;
+    double m_halfVMidDt;
+    double m_rho0;
+    double m_bulkNew;
+    double m_cvav;
+    double m_e0;
+    double m_v0;
+
+};
+
+// As we add more variations of evptn classes here this won't be only one available
+template<class SlipGeom, class Kinetics, class ThermoElastN, class EosModel>
+class pyEvptn_norm : public pyevptn_base
+{
+    public:
+    pyEvptn_norm(std::vector<double> &params) : pyevptn_base(params), 
+                                                kinetics(SlipGeom::nslip)
+    {
+
+        if (params.size() != (unsigned int) nParams) {
+            ECMECH_FAIL(__func__, "wrong number of params");
+        }
+
+        std::vector<double>::const_iterator parsIt = params.begin();
+
+        m_rho0 = *parsIt; ++parsIt;
+        m_cvav = *parsIt; ++parsIt;
+
+        m_tolerance = *parsIt; ++parsIt;
+
+        {
+            const std::vector<double> paramsThese(parsIt, parsIt + SlipGeom::nParams);
+            slipGeom.setParams(paramsThese); parsIt += SlipGeom::nParams;
+        }
+        {
+            const std::vector<double> paramsThese(parsIt, parsIt + ThermoElastN::nParams);
+            elastN.setParams(paramsThese); parsIt += ThermoElastN::nParams;
+        }
+        {
+            const std::vector<double> paramsThese(parsIt, parsIt + Kinetics::nParams);
+            kinetics.setParams(paramsThese); parsIt += Kinetics::nParams;
+        }
+        {
+            double bulkMod = elastN.getBulkMod();
+            std::vector<double> paramsThese(EosModel::nParams);
+            paramsThese[0] = m_rho0;
+            paramsThese[1] = bulkMod;
+            paramsThese[2] = m_cvav;
+            std::copy(parsIt, parsIt + nParamsEOS, paramsThese.begin() + nParamsEOSHave);
+
+            eos.setParams(paramsThese); parsIt += nParamsEOS;
+
+            {
+                double vMin, vMax;
+                eos.getInfo(vMin, vMax, m_e0, m_v0);
+            }
+        }
+
+        int iParam = parsIt - params.begin();
+        if (iParam != nParams) {
+            ECMECH_FAIL(__func__, "wrong number of params");
+        }
+        //////////////////////////////
+
+        m_rhvNames.clear();
+        m_rhvVals.clear();
+        m_rhvPlot.clear();
+        m_rhvState.clear();
+
+#if defined(ECMECH_USE_DPEFF)
+        m_rhvNames.push_back("effective_plastic_deformation_rate"); m_rhvVals.push_back(0.); m_rhvPlot.push_back(true); m_rhvState.push_back(true); // iHistA_shrateEff
+        m_rhvNames.push_back("effective_plastic_strain"); m_rhvVals.push_back(0.); m_rhvPlot.push_back(true); m_rhvState.push_back(true); // iHistA_shrEff
+#else
+        m_rhvNames.push_back("effective_shearing_rate"); m_rhvVals.push_back(0.); m_rhvPlot.push_back(true); m_rhvState.push_back(true); // iHistA_shrateEff
+        m_rhvNames.push_back("effective_shearing"); m_rhvVals.push_back(0.); m_rhvPlot.push_back(true); m_rhvState.push_back(true); // iHistA_shrEff
+#endif
+        m_rhvNames.push_back("flow_strength"); m_rhvVals.push_back(0.); m_rhvPlot.push_back(true); m_rhvState.push_back(false); // iHistA_flowStr
+        m_rhvNames.push_back("n_function_evals"); m_rhvVals.push_back(0.); m_rhvPlot.push_back(true); m_rhvState.push_back(false); // iHistA_nFEval
+        // numHistAux
+        //
+        for (int iTvec = 0; iTvec < ecmech::ntvec; ++iTvec) {
+            std::ostringstream os;
+            os << "deviatoric_elastic_strain_" << iTvec + 1;
+            m_rhvNames.push_back(os.str()); m_rhvVals.push_back(0.); m_rhvPlot.push_back(true); m_rhvState.push_back(true);
+        }
+
+        //
+        {
+            double qVal = 1.0;
+            for (int iQ = 0; iQ < ecmech::qdim; ++iQ) {
+                std::ostringstream os;
+                os << "quat_" << iQ + 1;
+                m_rhvNames.push_back(os.str()); m_rhvVals.push_back(qVal); m_rhvPlot.push_back(true); m_rhvState.push_back(true);
+                qVal = 0.0;
+            }
+        }
+        //
+        kinetics.getHistInfo(m_rhvNames, m_rhvVals, m_rhvPlot, m_rhvState);
+        //
+        for (int iSlip = 0; iSlip < SlipGeom::nslip; ++iSlip) {
+            std::ostringstream os;
+            os << "shearing_rate_" << iSlip + 1;
+            m_rhvNames.push_back(os.str()); m_rhvVals.push_back(0.); m_rhvPlot.push_back(true); m_rhvState.push_back(true);
+        }
+
+        //
+        if (m_rhvNames.size() != numHist) {
+            ECMECH_FAIL(__func__, "mismatch in numHist");
+        }
+    }
+
+    virtual ~pyEvptn_norm() {}
+
+    void setup( double    dt,
+                double    tolerance,
+                const double  * d_svec_kk_sm, // defRate,
+                const double  * w_veccp_sm, // spin
+                const double  * volRatio,
+                double  * eInt,
+                double  * stressSvecP,
+                double  * hist,
+                double  & tkelv,
+                double  * sdd,
+                double  * mtanSD,
+                int outputLevel = 0) override final
+    {
+        static const int iHistLbGdot = ecmech::evptn::NumHist<SlipGeom, Kinetics, ThermoElastN, EosModel>::iHistLbGdot;
+
+        m_dt = dt;
+        m_tolerance = tolerance;
+        m_tkelv = tkelv;
+
+        for (int i = 0; i < ecmech::nsvp; i++)
+        {
+            m_d_svec_kk_sm[i] = d_svec_kk_sm[i];
+            m_stressSvecP[i] = stressSvecP[i];
+        }
+
+        for (int i = 0; i < ecmech::nwvec; i++)
+        {
+            m_w_veccp_sm[i] = w_veccp_sm[i];
+        }
+
+        for (int i = 0; i < ecmech::ne; i++)
+        {
+            m_eInt[i] = eInt[i];
+        }
+
+        for (int i = 0; i < ecmech::nvr; i++)
+        {
+            m_volRatio[i] = volRatio[i];
+        }
+
+        for (int i = 0; i < numHist; i++)
+        {
+            m_hist[i] = hist[i];
+        }
+
+        // convert deformation rate convention
+        //
+        ecmech::svecToVecd(m_d_vecd_sm, m_d_svec_kk_sm);
+
+        // pointers to state
+        //
+        double* h_state = &(hist[ecmech::evptn::iHistLbH]);
+        double* gdot = &(hist[iHistLbGdot]);
+
+        for (int i_hist = 0; i_hist < ecmech::ntvec; i_hist++) {
+            m_e_vecd_n[i_hist] = hist[ecmech::evptn::iHistLbE + i_hist];
+        }
+
+        for (int i_hist = 0; i_hist < ecmech::qdim; i_hist++) {
+            m_quat_n[i_hist] = hist[ecmech::evptn::iHistLbQ + i_hist];
+        }
+
+        //
+        // normalize quat just in case
+        ecmech::vecsVNormalize<ecmech::qdim>(m_quat_n);
+
+        // EOS
+        //
+        double eOld = eInt[ecmech::i_ne_total];
+        double pOld = m_stressSvecP[6];
+        //
+        // get tkelv from beginning-of-step to avoid tangent stiffness contributions
+        {
+            double pBOS;
+            double vOld = m_volRatio[0];
+            eos.evalPT(pBOS, m_tkelv, vOld, eOld);
+        }
+        //
+        double tkelvNew ;
+        {
+        double dpde, dpdv, dtde;
+        ecmech::updateSimple<EosModel>(eos, m_pEOS, tkelvNew, m_eNew, m_bulkNew,
+                                       dpde, dpdv, dtde,
+                                       m_volRatio[1], m_volRatio[3],
+                                       eOld, pOld);
+        }
+
+        // update hardness state to the end of the step
+        // gdot is still at beginning-of-step
+        //
+        kinetics.updateH(m_hard_u, h_state, dt, gdot);
+        m_vNew = m_volRatio[1];
+
+        if (prob != nullptr)
+        {
+            delete prob;
+        }
+
+        prob = new ecmech::evptn::EvptnUpdstProblem<SlipGeom, Kinetics, ThermoElastN>
+                    (slipGeom, kinetics, elastN,
+                    m_dt,
+                    m_vNew, m_eNew, m_pEOS, m_tkelv,
+                    m_hard_u, m_e_vecd_n, m_quat_n,
+                    m_d_vecd_sm, m_w_veccp_sm);
+
+    }
+
+    void computeRJ(double * const resid,
+                   double * const Jacobian,
+                   const double * const x) override final
+    {
+        prob->computeRJ(resid, Jacobian, x);
+    };
+
+    void getState(const double * const x,
+                          double * const eInt,
+                          double * const stressSvecP,
+                          double * const hist,
+                          double& tkelv,
+                          double * const sdd) override final 
+    {
+        double* h_state = &(hist[ecmech::evptn::iHistLbH]);
+        double* gdot = &(hist[iHistLbGdot]);
+        double* e_vecd_u = &(hist[ecmech::evptn::iHistLbE]);
+        double* quat_u = &(hist[ecmech::evptn::iHistLbQ]);
+        // store updated state
+        //
+        prob->stateFromX(e_vecd_u, quat_u, x);
+        for (int i_hstate = 0; i_hstate < Kinetics::nH; i_hstate++) {
+            h_state[i_hstate] = m_hard_u[i_hstate];
+        }
+        //
+        {
+            const double* gdot_u = prob->getGdot();
+            for (int i_gdot = 0; i_gdot < SlipGeom::nslip; i_gdot++) {
+                gdot[i_gdot] = gdot_u[i_gdot];
+            }
+        }
+        //
+        hist[ecmech::evptn::iHistA_shrateEff] = prob->getShrateEff();
+        hist[ecmech::evptn::iHistA_shrEff] += hist[ecmech::evptn::iHistA_shrateEff] * m_dt;
+        //
+        {
+            double dEff = ecmech::vecd_Deff(m_d_vecd_sm);
+            double flow_strength = prob->getHdnScale();
+            if (dEff > ecmech::idp_tiny_sqrt) {
+                flow_strength = prob->getDisRate() / dEff;
+            }
+            hist[ecmech::evptn::iHistA_flowStr] = flow_strength;
+        }
+        //
+        hist[ecmech::evptn::iHistA_nFEval] = 0; // does _not_ include updateH iterations
+
+        // get Cauchy stress
+        //
+        double Cstr_vecds_lat[ecmech::nsvec];
+        prob->elastNEtoC(Cstr_vecds_lat, e_vecd_u);
+
+        double C_matx[ecmech::ndim * ecmech::ndim];
+        ecmech::quat_to_tensor(C_matx, quat_u);
+        //
+        double qr5x5_ls[ecmech::ntvec * ecmech::ntvec];
+        ecmech::get_rot_mat_vecd(qr5x5_ls, C_matx);
+        //
+        double Cstr_vecds_sm[ecmech::nsvec];
+        ecmech::vecsVMa<ecmech::ntvec>(Cstr_vecds_sm, qr5x5_ls, Cstr_vecds_lat);
+        Cstr_vecds_sm[ecmech::iSvecS] = Cstr_vecds_lat[ecmech::iSvecS];
+        //
+        // put end-of-step stress in stressSvecP
+        ecmech::vecdsToSvecP(stressSvecP, Cstr_vecds_sm);
+        //
+        // and now the second half of the trapezoidal integration
+        //
+        m_eDevTot += m_halfVMidDt * ecmech::vecsInnerSvecDev(stressSvecP, m_d_svec_kk_sm);
+
+        // adjust sign on quat so that as close as possible to quat_o;
+        // more likely to keep orientations clustered this way;
+        // this flip through the origin is equivalent under antipodal symmetry
+        //
+        if (ecmech::vecsyadotb<ecmech::qdim>(quat_u, m_quat_n) < ecmech::zero) {
+        for (int iQ = 0; iQ < ecmech::qdim; ++iQ) {
+            quat_u[iQ] = -quat_u[iQ];
+        }
+        }
+
+        {
+        double gmod = elastN.getGmod(m_tkelv, m_pEOS, m_eNew);
+        sdd[ecmech::i_sdd_bulk] = m_bulkNew;
+        sdd[ecmech::i_sdd_gmod] = gmod;
+        tkelv = m_tkelv;
+
+        }
+#ifdef ECMECH_DEBUG
+        assert(ecmech::nsdd == 2);
+#endif
+
+        m_eNew += m_eDevTot;
+        //
+        // could update pressure and temperature again, but do not bother
+
+        eInt[ecmech::i_ne_total] = m_eNew;
+#ifdef ECMECH_DEBUG
+        assert(ecmech::ne == 1);
+#endif 
+    }
+    private:
+
+    SlipGeom slipGeom;
+    Kinetics kinetics;
+    ThermoElastN elastN;
+    EosModel eos;
+    ecmech::evptn::EvptnUpdstProblem<SlipGeom, Kinetics, ThermoElastN>* prob = nullptr;
+
+
+    static constexpr int iHistLbGdot = ecmech::evptn::NumHist<SlipGeom, Kinetics, ThermoElastN, EosModel>::iHistLbGdot;
+    static constexpr int numHist = ecmech::evptn::NumHist<SlipGeom, Kinetics, ThermoElastN, EosModel>::numHist;
+    static constexpr int nH = Kinetics::nH;
+    static constexpr int nslip = SlipGeom::nslip;
+
+    static constexpr int nParamsEOSHave = 3; // number that get from 'elsewhere' // these are assumed to go in first
+    static constexpr int nParamsEOS = EosModel::nParams - nParamsEOSHave;
+    static constexpr int nParams = 2 + 1 + // rho0, cvav, tolerance
+                         Kinetics::nParams + ThermoElastN::nParams + nParamsEOS;
+
+    //
+    double m_hist[numHist];
+    double m_hard_u[nH];
+
+};
+
+
+// Should probably figure out a better way to do this sometime in the future...
+typedef pyEvptn_norm<ecmech::SlipGeomFCC, ecmech::Kin_FCC_A, ecmech::evptn::ThermoElastNCubic, ecmech::EosModelConst<false> > pyMatModelEvptn_FCC_A;
+typedef pyEvptn_norm<ecmech::SlipGeomFCC, ecmech::Kin_FCC_AH, ecmech::evptn::ThermoElastNCubic, ecmech::EosModelConst<false> > pyMatModelEvptn_FCC_AH;
+typedef pyEvptn_norm<ecmech::SlipGeomFCC, ecmech::Kin_FCC_B, ecmech::evptn::ThermoElastNCubic, ecmech::EosModelConst<false> > pyMatModelEvptn_FCC_B;
+typedef pyEvptn_norm<ecmech::SlipGeom_BCC_A, ecmech::Kin_BCC_A, ecmech::evptn::ThermoElastNCubic, ecmech::EosModelConst<false> > pyMatModelEvptn_BCC_A;
+typedef pyEvptn_norm<ecmech::SlipGeom_BCC_A, ecmech::Kin_FCC_A, ecmech::evptn::ThermoElastNCubic, ecmech::EosModelConst<false> > pyMatModelEvptn_BCC_B;
+typedef pyEvptn_norm<ecmech::SlipGeom_BCC_A, ecmech::Kin_FCC_AH, ecmech::evptn::ThermoElastNCubic, ecmech::EosModelConst<false> > pyMatModelEvptn_BCC_BH;
+typedef pyEvptn_norm<ecmech::SlipGeom_HCP_A, ecmech::Kin_HCP_A, ecmech::evptn::ThermoElastNHexag, ecmech::EosModelConst<false> > pyMatModelEvptn_HCP_A;
+
+#endif

--- a/pyecmech/ecmech_classes.hpp
+++ b/pyecmech/ecmech_classes.hpp
@@ -5,6 +5,8 @@
 #include "ECMech_core.h"
 #include "ECMech_cases.h"
 
+#if defined(ECMECH_PYDEV)
+
 class pyevptn_base
 {
     public:
@@ -420,5 +422,7 @@ typedef pyEvptn_norm<ecmech::SlipGeom_BCC_A, ecmech::Kin_BCC_A, ecmech::evptn::T
 typedef pyEvptn_norm<ecmech::SlipGeom_BCC_A, ecmech::Kin_FCC_A, ecmech::evptn::ThermoElastNCubic, ecmech::EosModelConst<false> > pyMatModelEvptn_BCC_B;
 typedef pyEvptn_norm<ecmech::SlipGeom_BCC_A, ecmech::Kin_FCC_AH, ecmech::evptn::ThermoElastNCubic, ecmech::EosModelConst<false> > pyMatModelEvptn_BCC_BH;
 typedef pyEvptn_norm<ecmech::SlipGeom_HCP_A, ecmech::Kin_HCP_A, ecmech::evptn::ThermoElastNHexag, ecmech::EosModelConst<false> > pyMatModelEvptn_HCP_A;
+
+#endif
 
 #endif

--- a/pyecmech/ecmech_classes.hpp
+++ b/pyecmech/ecmech_classes.hpp
@@ -13,12 +13,13 @@ class pyevptn_base
     /// Provides history names, initial values, 
     /// whether the param is meant to be plotted,
     /// and whether its a state variable
-    void getHistoryInfo(std::vector<std::string> names,
-                        std::vector<double>vals,
-                        std::vector<bool> plot,
-                        std::vector<bool> state)
+    void getHistoryInfo(std::vector<std::string>& names,
+                        std::vector<double>& vals,
+                        std::vector<bool>& plot,
+                        std::vector<bool>& state)
     {
         const int numHist = m_rhvNames.size();
+
         names.resize(numHist); std::copy(m_rhvNames.begin(), m_rhvNames.end(), names.begin() );
         vals.resize(numHist); std::copy(m_rhvVals.begin(), m_rhvVals.end(), vals.begin() );
         plot.resize(numHist); std::copy(m_rhvPlot.begin(), m_rhvPlot.end(), plot.begin() );

--- a/pyecmech/ecmech_classes.hpp
+++ b/pyecmech/ecmech_classes.hpp
@@ -34,10 +34,7 @@ class pyevptn_base
                         double  * eInt,
                         double  * stressSvecP,
                         double  * hist,
-                        double  & tkelv,
-                        double  * sdd,
-                        double  * mtanSD,
-                        int outputLevel = 0) = 0;
+                        double  & tkelv) = 0;
     /// Should be handed to nonlinear solver for each time step and point
     /// for the Jacobian/gradient and function calculations
     virtual void computeRJ(double * const resid,
@@ -195,10 +192,7 @@ class pyEvptn_norm : public pyevptn_base
                 double  * eInt,
                 double  * stressSvecP,
                 double  * hist,
-                double  & tkelv,
-                double  * sdd,
-                double  * mtanSD,
-                int outputLevel = 0) override final
+                double  & tkelv) override final
     {
         static const int iHistLbGdot = ecmech::evptn::NumHist<SlipGeom, Kinetics, ThermoElastN, EosModel>::iHistLbGdot;
 

--- a/pyecmech/ecmech_classes.hpp
+++ b/pyecmech/ecmech_classes.hpp
@@ -1,7 +1,6 @@
 #ifndef ECMECH_CLASSES_HPP
 #define ECMECH_CLASSES_HPP
 
-#include "ECMech_const.h"
 #include "ECMech_core.h"
 #include "ECMech_cases.h"
 

--- a/pyecmech/ecmech_pybind11.cpp
+++ b/pyecmech/ecmech_pybind11.cpp
@@ -1,5 +1,6 @@
 #include <pybind11/pybind11.h>
 #include<pybind11/numpy.h>
+#include "ECMech_const.h"
 #include "ecmechpy.hpp"
 
 namespace py = pybind11;
@@ -13,10 +14,19 @@ PYBIND11_MODULE(ecmech, m) {
            :toctree: _generate
            ECMech
     )pbdoc";
+    py::module constants = m.def_submodule("constants"); // create namespace
+    constants.attr("nsvec") = &ecmech::nsvec;
+    constants.attr("nsvec2") = &ecmech::nsvec2;
+    constants.attr("ntvec") = &ecmech::ntvec;
+    constants.attr("nvr") = &ecmech::nvr;
+    constants.attr("ne") = &ecmech::ne;
+    constants.attr("nsvp") = &ecmech::nsvp;
+    constants.attr("nwvec") = &ecmech::nwvec;
+    constants.attr("nsdd") = &ecmech::nsdd;
 
-    py::class_<ECMechPy>(m, "ECMech", "Provides ECMechPy")
+    py::class_<pyECMech>(m, "pyECMech", "Provides pyECMech")
         .def(py::init([](std::string &model_name, py_darray &params) {
-            return std::unique_ptr<ECMechPy>(new ECMechPy(model_name, params));
+            return std::unique_ptr<pyECMech>(new pyECMech(model_name, params));
         }),
         R"pbdoc(
             std::string model_name - model name choices are:
@@ -34,7 +44,7 @@ PYBIND11_MODULE(ecmech, m) {
                                      and norm refers an implicit beginning of time step hardening state update and
                                      an implicit end of time step coupled elastic strain and lattice rotation update.
             py_darray params - model parameters for the provided model name.)pbdoc")
-        .def("getHistoryInfo", &ECMechPy::getHistoryInfo, py::return_value_policy::take_ownership,
+        .def("getHistoryInfo", &pyECMech::getHistoryInfo, py::return_value_policy::take_ownership,
              R"pbdoc(
                 Output: names, vals, plot, state
                 names: the history names as a list of strings, 
@@ -42,7 +52,54 @@ PYBIND11_MODULE(ecmech, m) {
                 plot: whether the history variable should be plotted as a list of booleans,
                 state: whether the history variable is a state variable as a list of booleans.
                 )pbdoc")
-        .def("setup", &ECMechPy::setup,
+        .def("getNumberHistory", &pyECMech::getNumberHistory, py::return_value_policy::take_ownership,
+            R"pbdoc(
+                Output: numHist
+                numHist: the number of history variables
+            )pbdoc")
+        .def("solve", &pyECMech::solve,
+             R"pbdoc(
+                 double dt, // delta time
+                 py_darray& d_svec_kk_sm, // deformation rate in sample frame
+                 py_darray& w_veccp_sm, // spin in sample rate
+                 py_darray& volRatio, // volume ratio
+                 py_darray& eInt, // internal energy
+                 py_darray& stressSvecP, // stress deviatoric vector + pressure term
+                 py_darray& hist, // history variable
+                 py_darray& tkelv // current temperature in kelvin
+                 py_darray& sdd // sdd array
+             )pbdoc");
+
+#if defined(ECMECH_PYDEV)
+    py::class_<pyECMechDev>(m, "pyECMechDev", "Provides pyECMechDev")
+        .def(py::init([](std::string &model_name, py_darray &params) {
+            return std::unique_ptr<pyECMechDev>(new pyECMechDev(model_name, params));
+        }),
+        R"pbdoc(
+            std::string model_name - model name choices are:
+                                     voce_fcc_norm,
+                                     voce_nl_fcc_norm,
+                                     voce_bcc_norm,
+                                     voce_nl_bcc_norm,
+                                     km_bal_dd_fcc_norm,
+                                     km_bal_dd_bcc_norm,
+                                     km_bal_dd_hcp_norm
+                                     where voce refers to a Voce hardening law with power law slip kinetics,
+                                     voce_nl refers to a nonlinear Voce hardening law with power law slip kinetics,
+                                     km_bal_dd refers to a single Kocks-Mecking dislocation density hardening with
+                                     balanced thermally activated MTS-like slip kinetics with phonon drag effects,
+                                     and norm refers an implicit beginning of time step hardening state update and
+                                     an implicit end of time step coupled elastic strain and lattice rotation update.
+            py_darray params - model parameters for the provided model name.)pbdoc")
+        .def("getHistoryInfo", &pyECMechDev::getHistoryInfo, py::return_value_policy::take_ownership,
+             R"pbdoc(
+                Output: names, vals, plot, state
+                names: the history names as a list of strings, 
+                vals: the initial values of the history name as numpy array, 
+                plot: whether the history variable should be plotted as a list of booleans,
+                state: whether the history variable is a state variable as a list of booleans.
+                )pbdoc")
+        .def("setup", &pyECMechDev::setup,
              R"pbdoc(
                  double dt, // delta time
                  double tolerance, // solver tolerance - not used
@@ -54,13 +111,13 @@ PYBIND11_MODULE(ecmech, m) {
                  py_darray hist, // history variable
                  double& tkelv // current temperature in kelvin
              )pbdoc")
-        .def("computeRJ", &ECMechPy::computeRJ,
+        .def("computeRJ", &pyECMechDev::computeRJ,
              R"pbdoc(
                 py_darray &resid, // residual of system
                 py_darray &J, // Jacobian of system
                 py_darray &x // input solution vector
              )pbdoc")
-        .def("getState", &ECMechPy::getState,
+        .def("getState", &pyECMechDev::getState,
              R"pbdoc(
                 const py_darray &x, // input solution vector
                 py_darray &eInt, // internal energy
@@ -69,7 +126,7 @@ PYBIND11_MODULE(ecmech, m) {
                 double& tkelv, // current temperature
                 py_darray &sdd // sdd array
              )pbdoc");
-
+#endif
 
 #ifdef VERSION_INFO
     m.attr("__version__") = VERSION_INFO;

--- a/pyecmech/ecmech_pybind11.cpp
+++ b/pyecmech/ecmech_pybind11.cpp
@@ -1,18 +1,21 @@
 #include <pybind11/pybind11.h>
 #include<pybind11/numpy.h>
+
+#include "ECMech_core.h"
 #include "ECMech_const.h"
+
 #include "ecmechpy.hpp"
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(ecmech, m) {
+PYBIND11_MODULE(pyecmech, m) {
     m.doc() = R"pbdoc(
         ECMech Python Bindings
         -----------------------
-        .. currentmodule:: ecmech
+        .. currentmodule:: pyecmech
         .. autosummary::
            :toctree: _generate
-           ECMech
+           pyECMech
     )pbdoc";
     py::module constants = m.def_submodule("constants"); // create namespace
     constants.attr("nsvec") = &ecmech::nsvec;

--- a/pyecmech/ecmech_pybind11.cpp
+++ b/pyecmech/ecmech_pybind11.cpp
@@ -1,0 +1,81 @@
+#include <pybind11/pybind11.h>
+#include<pybind11/numpy.h>
+#include "ecmechpy.hpp"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(ecmech, m) {
+    m.doc() = R"pbdoc(
+        ECMech Python Bindings
+        -----------------------
+        .. currentmodule:: ecmech
+        .. autosummary::
+           :toctree: _generate
+           ECMech
+    )pbdoc";
+
+    py::class_<ECMechPy>(m, "ECMech", "Provides ECMechPy")
+        .def(py::init([](std::string &model_name, py_darray &params) {
+            return std::unique_ptr<ECMechPy>(new ECMechPy(model_name, params));
+        }),
+        R"pbdoc(
+            std::string model_name - model name choices are:
+                                     voce_fcc_norm,
+                                     voce_nl_fcc_norm,
+                                     voce_bcc_norm,
+                                     voce_nl_bcc_norm,
+                                     km_bal_dd_fcc_norm,
+                                     km_bal_dd_bcc_norm,
+                                     km_bal_dd_hcp_norm
+                                     where voce refers to a Voce hardening law with power law slip kinetics,
+                                     voce_nl refers to a nonlinear Voce hardening law with power law slip kinetics,
+                                     km_bal_dd refers to a single Kocks-Mecking dislocation density hardening with
+                                     balanced thermally activated MTS-like slip kinetics with phonon drag effects,
+                                     and norm refers an implicit beginning of time step hardening state update and
+                                     an implicit end of time step coupled elastic strain and lattice rotation update.
+            py_darray params - model parameters for the provided model name.)pbdoc")
+        .def("getHistInfo", &ECMechPy::getHistInfo, py::return_value_policy::take_ownership,
+             R"pbdoc(
+                Output: names, vals, plot, state
+                names: the history names as a list of strings, 
+                vals: the initial values of the history name as numpy array, 
+                plot: whether the history variable should be plotted as a list of booleans,
+                state: whether the history variable is a state variable as a list of booleans.
+                )pbdoc")
+        .def("setup", &ECMechPy::setup,
+             R"pbdoc(
+                 double dt, // delta time
+                 double tolerance, // solver tolerance - not used
+                 py_darray d_svec_kk_sm, // deformation rate in sample frame
+                 py_darray w_veccp_sm, // spin in sample rate
+                 py_darray volRatio, // volume ratio
+                 py_darray eInt, // internal energy
+                 py_darray stressSvecP, // stress deviatoric vector + pressure term
+                 py_darray hist, // history variable
+                 double& tkelv, // current temperature in kelvin
+                 py_darray sdd, // sdd array - not used
+                 py_darray mtanSD // tangent modulus - not used
+             )pbdoc")
+        .def("computeRJ", &ECMechPy::computeRJ,
+             R"pbdoc(
+                py_darray &resid, // residual of system
+                py_darray &J, // Jacobian of system
+                py_darray &x // input solution vector
+             )pbdoc")
+        .def("getState", &ECMechPy::getState,
+             R"pbdoc(
+                const py_darray &x, // input solution vector
+                py_darray &eInt, // internal energy
+                py_darray &stressSvecP, // stress deviatoric vector + pressure term
+                py_darray &hist, // history variable
+                double& tkelv, // current temperature
+                py_darray &sdd // sdd array
+             )pbdoc");
+
+
+#ifdef VERSION_INFO
+    m.attr("__version__") = VERSION_INFO;
+#else
+    m.attr("__version__") = "dev";
+#endif
+}

--- a/pyecmech/ecmech_pybind11.cpp
+++ b/pyecmech/ecmech_pybind11.cpp
@@ -52,9 +52,7 @@ PYBIND11_MODULE(ecmech, m) {
                  py_darray eInt, // internal energy
                  py_darray stressSvecP, // stress deviatoric vector + pressure term
                  py_darray hist, // history variable
-                 double& tkelv, // current temperature in kelvin
-                 py_darray sdd, // sdd array - not used
-                 py_darray mtanSD // tangent modulus - not used
+                 double& tkelv // current temperature in kelvin
              )pbdoc")
         .def("computeRJ", &ECMechPy::computeRJ,
              R"pbdoc(

--- a/pyecmech/ecmech_pybind11.cpp
+++ b/pyecmech/ecmech_pybind11.cpp
@@ -34,7 +34,7 @@ PYBIND11_MODULE(ecmech, m) {
                                      and norm refers an implicit beginning of time step hardening state update and
                                      an implicit end of time step coupled elastic strain and lattice rotation update.
             py_darray params - model parameters for the provided model name.)pbdoc")
-        .def("getHistInfo", &ECMechPy::getHistInfo, py::return_value_policy::take_ownership,
+        .def("getHistoryInfo", &ECMechPy::getHistoryInfo, py::return_value_policy::take_ownership,
              R"pbdoc(
                 Output: names, vals, plot, state
                 names: the history names as a list of strings, 

--- a/pyecmech/ecmechpy.cpp
+++ b/pyecmech/ecmechpy.cpp
@@ -206,12 +206,12 @@ pyECMechDev::getHistoryInfo()
 
 void pyECMechDev::setup(double dt,
                      double tolerance,
-                     py_darray d_svec_kk_sm, // defRate,
-                     py_darray w_veccp_sm, // spin
-                     py_darray volRatio,
-                     py_darray eInt,
-                     py_darray stressSvecP,
-                     py_darray hist,
+                     py_darray &d_svec_kk_sm, // defRate,
+                     py_darray &w_veccp_sm, // spin
+                     py_darray &volRatio,
+                     py_darray &eInt,
+                     py_darray &stressSvecP,
+                     py_darray &hist,
                      double& tkelv)
 {
 

--- a/pyecmech/ecmechpy.cpp
+++ b/pyecmech/ecmechpy.cpp
@@ -1,0 +1,112 @@
+#include "ecmechpy.hpp"
+
+#include <random>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <cmath>
+#include <limits>
+
+ECMechPy::ECMechPy(std::string model_name, py_darray &params)
+{
+
+   pybind11::buffer_info buf1 = params.request();
+
+   if (buf1.ndim != 1)
+   {
+      throw std::runtime_error("Number of dimensions must be two");
+   }
+   const int lparam = buf1.shape[0];
+   double *param_data = (double*) buf1.ptr;
+
+   std::vector<double> cparams;
+   cparams.resize(lparam);
+
+   for (int i = 0; i < lparam; i++)
+   {
+      cparams[i] = param_data[i];
+   }
+
+   // Only care about these for now. We can add ones later on.
+   if(std::string(model_name) == "voce_fcc_norm") {
+      model = new pyMatModelEvptn_FCC_A(cparams);
+   } else if (std::string(model_name) == "voce_nl_fcc_norm") {
+      model = new pyMatModelEvptn_FCC_AH(cparams);
+   } else if (std::string(model_name) == "voce_bcc_norm") {
+      model = new matModelEvptn_BCC_B(cparams);
+   } else if (std::string(model_name) == "voce_nl_bcc_norm") {
+      model = new matModelEvptn_BCC_BH(cparams);
+   } else if (std::string(model_name) == "km_bal_dd_fcc_norm") {
+      model = new pyMatModelEvptn_FCC_B(cparams);
+   } else if (std::string(model_name) == "km_bal_dd_bcc_norm") {
+      model = new pyMatModelEvptn_BCC_A(cparams);
+   } else if (std::string(model_name) == "km_bal_dd_hcp_norm") {
+      model = new pyMatModelEvptn_HCP_A(cparams);
+   } else {
+      throw std::runtime_error("Provided an unknown model name");
+   }
+}
+
+std::tuple<std::vector<std::string>, py_darray, std::vector<bool>, std::vector<bool>>
+ECMechPy::getHistInfo()
+{
+   std::vector<std::string> names;
+   std::vector<bool> state;
+   std::vector<bool> plot;
+   std::vector<double> vals;
+
+   model->getHistInfo(names, vals, plot, state);
+
+   py_darray py_vals = pybind11::array(vals.size(), vals.pointer());
+
+   return std::make_tuple(names, py_vals, plot, state);
+}
+
+void ECMechPy::setup(double dt,
+                     double tolerance,
+                     py_darray d_svec_kk_sm, // defRate,
+                     py_darray w_veccp_sm, // spin
+                     py_darray volRatio,
+                     py_darray eInt,
+                     py_darray stressSvecP,
+                     py_darray hist,
+                     double& tkelv,
+                     py_darray sdd,
+                     py_darray mtanSD)
+{
+
+   model->setup(dt, tolerance,
+               (double*) d_svec_kk_sm.request().ptr,
+               (double*) w_veccp_sm.request().ptr,
+               (double*) volRatio.request().ptr,
+               (double*) eInt.request().ptr,
+               (double*) stressSvecP.request().ptr,
+               (double*) hist.request().ptr,
+               tkelv,
+               (double*) sdd.request().ptr,
+               (double*) mtanSD.request().ptr);
+}
+
+void ECMechPy::computeRJ(py_darray &resid,
+                    py_darray &J,
+                    py_darray &x)
+{
+   model->computeRJ((double*) resid.request().ptr,
+                    (double*) J.request().ptr,
+                    (double*) x.request().ptr);
+}
+
+void ECMechPy::getState(const py_darray &x,
+                        py_darray &eInt,
+                        py_darray &stressSvecP,
+                        py_darray &hist,
+                        double& tkelv,
+                        py_darray &sdd)
+{
+   model->getState((double*) x.request().ptr,
+                   (double*) eInt.request().ptr,
+                   (double*) stressSvecP.request().ptr,
+                   (double*) hist.request().ptr,
+                   tkelv,
+                   (double*) sdd.request().ptr);
+}

--- a/pyecmech/ecmechpy.cpp
+++ b/pyecmech/ecmechpy.cpp
@@ -33,9 +33,9 @@ ECMechPy::ECMechPy(std::string model_name, py_darray &params)
    } else if (std::string(model_name) == "voce_nl_fcc_norm") {
       model = new pyMatModelEvptn_FCC_AH(cparams);
    } else if (std::string(model_name) == "voce_bcc_norm") {
-      model = new matModelEvptn_BCC_B(cparams);
+      model = new pyMatModelEvptn_BCC_B(cparams);
    } else if (std::string(model_name) == "voce_nl_bcc_norm") {
-      model = new matModelEvptn_BCC_BH(cparams);
+      model = new pyMatModelEvptn_BCC_BH(cparams);
    } else if (std::string(model_name) == "km_bal_dd_fcc_norm") {
       model = new pyMatModelEvptn_FCC_B(cparams);
    } else if (std::string(model_name) == "km_bal_dd_bcc_norm") {
@@ -48,16 +48,16 @@ ECMechPy::ECMechPy(std::string model_name, py_darray &params)
 }
 
 std::tuple<std::vector<std::string>, py_darray, std::vector<bool>, std::vector<bool>>
-ECMechPy::getHistInfo()
+ECMechPy::getHistoryInfo()
 {
    std::vector<std::string> names;
    std::vector<bool> state;
    std::vector<bool> plot;
    std::vector<double> vals;
 
-   model->getHistInfo(names, vals, plot, state);
+   model->getHistoryInfo(names, vals, plot, state);
 
-   py_darray py_vals = pybind11::array(vals.size(), vals.pointer());
+   py_darray py_vals = pybind11::array(vals.size(), vals.data());
 
    return std::make_tuple(names, py_vals, plot, state);
 }

--- a/pyecmech/ecmechpy.cpp
+++ b/pyecmech/ecmechpy.cpp
@@ -70,9 +70,7 @@ void ECMechPy::setup(double dt,
                      py_darray eInt,
                      py_darray stressSvecP,
                      py_darray hist,
-                     double& tkelv,
-                     py_darray sdd,
-                     py_darray mtanSD)
+                     double& tkelv)
 {
 
    model->setup(dt, tolerance,
@@ -82,9 +80,7 @@ void ECMechPy::setup(double dt,
                (double*) eInt.request().ptr,
                (double*) stressSvecP.request().ptr,
                (double*) hist.request().ptr,
-               tkelv,
-               (double*) sdd.request().ptr,
-               (double*) mtanSD.request().ptr);
+               tkelv);
 }
 
 void ECMechPy::computeRJ(py_darray &resid,

--- a/pyecmech/ecmechpy.cpp
+++ b/pyecmech/ecmechpy.cpp
@@ -1,4 +1,5 @@
 #include "ecmechpy.hpp"
+#include "ECMech_cases.h"
 
 #include <random>
 #include <iostream>
@@ -7,14 +8,155 @@
 #include <cmath>
 #include <limits>
 
-ECMechPy::ECMechPy(std::string model_name, py_darray &params)
+typedef ecmech::evptn::matModel<ecmech::SlipGeom_BCC_A, ecmech::Kin_FCC_A, 
+               ecmech::evptn::ThermoElastNCubic, ecmech::EosModelConst<false> >
+               matModelEvptn_BCC_B;
+
+typedef ecmech::evptn::matModel<ecmech::SlipGeom_BCC_A, ecmech::Kin_FCC_AH, 
+               ecmech::evptn::ThermoElastNCubic, ecmech::EosModelConst<false> >
+               matModelEvptn_BCC_BH;
+
+namespace
+{
+   bool check2D_dim(py_darray &var, const int dim1, const int dim2, const std::string str)
+   {
+      pybind11::buffer_info buf1 = var.request();
+
+      if (buf1.ndim != 2)
+      {
+         std::string err = "Number of dimensions must be two for variable: " + str;
+         throw std::runtime_error(err.c_str());
+      }
+
+      if (buf1.shape[0] != dim1 || buf1.shape[1] != dim2)
+      {
+         const int bs0 = buf1.shape[0];
+         const int bs1 = buf1.shape[1];
+         std::string err = "Dimensions for variable: " + str + " should be (" 
+                                  + std::to_string(dim1) + " , " + std::to_string(dim2) + ") but got: ("
+                                  + std::to_string(bs0) + " , " + std::to_string(bs1) + ")";
+         throw std::runtime_error(err.c_str());
+      }
+      return true;
+   }
+}
+
+pyECMech::pyECMech(std::string model_name, py_darray &params)
 {
 
    pybind11::buffer_info buf1 = params.request();
 
    if (buf1.ndim != 1)
    {
-      throw std::runtime_error("Number of dimensions must be two");
+      throw std::runtime_error("Number of dimensions must be one");
+   }
+   const int lparam = buf1.shape[0];
+   double *param_data = (double*) buf1.ptr;
+
+   std::vector<double> cparams;
+   cparams.resize(lparam);
+
+   for (int i = 0; i < lparam; i++)
+   {
+      cparams[i] = param_data[i];
+   }
+
+   std::vector<int> opts;
+   std::vector<std::string> strs;
+
+   // Only care about these for now. We can add ones later on.
+   if(std::string(model_name) == "voce_fcc_norm") {
+      model = ecmech::makeMatModel("evptn_FCC_A");
+      model->initFromParams(opts, cparams, strs);
+   } else if (std::string(model_name) == "voce_nl_fcc_norm") {
+      model = ecmech::makeMatModel("evptn_FCC_AH");
+      model->initFromParams(opts, cparams, strs);
+   } else if (std::string(model_name) == "voce_bcc_norm") {
+      matModelEvptn_BCC_B* mmECMEvptn = new matModelEvptn_BCC_B();
+      model = dynamic_cast<ecmech::matModelBase*>(mmECMEvptn);
+      model->initFromParams(opts, cparams, strs);
+   } else if (std::string(model_name) == "voce_nl_bcc_norm") {
+      matModelEvptn_BCC_BH* mmECMEvptn = new matModelEvptn_BCC_BH();
+      model = dynamic_cast<ecmech::matModelBase*>(mmECMEvptn);     
+      model->initFromParams(opts, cparams, strs);
+   } else if (std::string(model_name) == "km_bal_dd_fcc_norm") {
+      model = ecmech::makeMatModel("evptn_FCC_B");
+      model->initFromParams(opts, cparams, strs);
+   } else if (std::string(model_name) == "km_bal_dd_bcc_norm") {
+      model = ecmech::makeMatModel("evptn_BCC_A");
+      model->initFromParams(opts, cparams, strs);
+   } else if (std::string(model_name) == "km_bal_dd_hcp_norm") {
+      model = ecmech::makeMatModel("evptn_FCC_A");
+      model->initFromParams(opts, cparams, strs);
+   } else {
+      throw std::runtime_error("Provided an unknown model name");
+   }
+
+   // Python runs should always be on the CPU for now unless we end up doing some form of memory
+   // management on our side of things.
+   model->setExecutionStrategy(ecmech::ExecutionStrategy::CPU);
+   model->complete();
+}
+
+std::tuple<std::vector<std::string>, py_darray, std::vector<bool>, std::vector<bool>>
+pyECMech::getHistoryInfo()
+{
+   std::vector<std::string> names;
+   std::vector<bool> state;
+   std::vector<bool> plot;
+   std::vector<double> vals;
+
+   model->getHistInfo(names, vals, plot, state);
+
+   py_darray py_vals = pybind11::array(vals.size(), vals.data());
+
+   return std::make_tuple(names, py_vals, plot, state);
+}
+
+void pyECMech::solve(double dt,
+                     py_darray &d_svec_kk_sm, // defRate,
+                     py_darray &w_veccp_sm, // spin
+                     py_darray &volRatio,
+                     py_darray &eInt,
+                     py_darray &stressSvecP,
+                     py_darray &hist,
+                     py_darray &tkelv,
+                     py_darray &sdd,
+                     const int nPassed)
+{
+   // Check that the dimensions for everything is correct
+   check2D_dim(d_svec_kk_sm, nPassed, ecmech::nsvp, "d_svec_kk_sm");
+   check2D_dim(w_veccp_sm, nPassed, ecmech::nwvec, "w_veccp_sm");
+   check2D_dim(volRatio, nPassed, ecmech::nvr, "volRatio");
+   check2D_dim(eInt, nPassed, ecmech::ne, "eInt");
+   check2D_dim(stressSvecP, nPassed, ecmech::nsvp, "stressSvecP");
+   check2D_dim(hist, nPassed, model->getNumHist(), "hist");
+   check2D_dim(tkelv, nPassed, 1, "tkelv");
+   check2D_dim(sdd, nPassed, ecmech::nsdd, "sdd");
+   
+   model->getResponseECM(dt,
+                         (double*) d_svec_kk_sm.request().ptr,
+                         (double*) w_veccp_sm.request().ptr,
+                         (double*) volRatio.request().ptr,
+                         (double*) eInt.request().ptr,
+                         (double*) stressSvecP.request().ptr,
+                         (double*) hist.request().ptr,
+                         (double*) tkelv.request().ptr,
+                         (double*) sdd.request().ptr,
+                         nullptr,
+                         nPassed);
+}
+
+#if defined(ECMECH_PYDEV)
+
+pyECMechDev::pyECMechDev(std::string model_name, py_darray &params)
+{
+
+   pybind11::buffer_info buf1 = params.request();
+
+   if (buf1.ndim != 1)
+   {
+      throw std::runtime_error("Number of dimensions must be one");
    }
    const int lparam = buf1.shape[0];
    double *param_data = (double*) buf1.ptr;
@@ -48,7 +190,7 @@ ECMechPy::ECMechPy(std::string model_name, py_darray &params)
 }
 
 std::tuple<std::vector<std::string>, py_darray, std::vector<bool>, std::vector<bool>>
-ECMechPy::getHistoryInfo()
+pyECMechDev::getHistoryInfo()
 {
    std::vector<std::string> names;
    std::vector<bool> state;
@@ -62,7 +204,7 @@ ECMechPy::getHistoryInfo()
    return std::make_tuple(names, py_vals, plot, state);
 }
 
-void ECMechPy::setup(double dt,
+void pyECMechDev::setup(double dt,
                      double tolerance,
                      py_darray d_svec_kk_sm, // defRate,
                      py_darray w_veccp_sm, // spin
@@ -83,7 +225,7 @@ void ECMechPy::setup(double dt,
                tkelv);
 }
 
-void ECMechPy::computeRJ(py_darray &resid,
+void pyECMechDev::computeRJ(py_darray &resid,
                     py_darray &J,
                     py_darray &x)
 {
@@ -92,7 +234,7 @@ void ECMechPy::computeRJ(py_darray &resid,
                     (double*) x.request().ptr);
 }
 
-void ECMechPy::getState(const py_darray &x,
+void pyECMechDev::getState(const py_darray &x,
                         py_darray &eInt,
                         py_darray &stressSvecP,
                         py_darray &hist,
@@ -106,3 +248,5 @@ void ECMechPy::getState(const py_darray &x,
                    tkelv,
                    (double*) sdd.request().ptr);
 }
+
+#endif

--- a/pyecmech/ecmechpy.hpp
+++ b/pyecmech/ecmechpy.hpp
@@ -18,7 +18,7 @@ class ECMechPy
       ECMechPy(std::string model_name, py_darray &params);
 
       std::tuple<std::vector<std::string>, py_darray, std::vector<bool>, std::vector<bool>>
-      getHistInfo();
+      getHistoryInfo();
 
       void setup(double dt,
                  double tolerance,

--- a/pyecmech/ecmechpy.hpp
+++ b/pyecmech/ecmechpy.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "ecmech_classes.hpp"
+#include "ECMech_core.h"
 #include "ECMech_matModelBase.h"
+#include "ecmech_classes.hpp"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/pyecmech/ecmechpy.hpp
+++ b/pyecmech/ecmechpy.hpp
@@ -1,7 +1,7 @@
-#ifndef ECMECHPY_HPP
-#define ECMECHPY_HPP
+#pragma once
 
 #include "ecmech_classes.hpp"
+#include "ECMech_matModelBase.h"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -10,25 +10,55 @@
 typedef typename pybind11::array_t<double> py_darray;
 typedef typename pybind11::array_t<int32_t> py_iarray;
 
-class ECMechPy
+class pyECMech
+{
+   private:
+      ecmech::matModelBase* model = nullptr;
+   public:
+      pyECMech(std::string model_name, py_darray &params);
+
+      std::tuple<std::vector<std::string>, py_darray, std::vector<bool>, std::vector<bool>>
+      getHistoryInfo();
+
+      int getNumberHistory() { return model->getNumHist(); }
+
+      void solve(double dt,
+                 py_darray &d_svec_kk_sm,
+                 py_darray &w_veccp_sm,
+                 py_darray &volRatio,
+                 py_darray &eInt,
+                 py_darray &stressSvecP,
+                 py_darray &hist,
+                 py_darray &tkelv,
+                 py_darray &sddv,
+                 const int nPassed);
+
+      ~pyECMech()
+      {
+         delete model;
+      }
+};
+
+#if defined(ECMECH_PYDEV)
+class pyECMechDev
 {
    private:
       pyevptn_base* model = nullptr;
    public:
-      ECMechPy(std::string model_name, py_darray &params);
+      pyECMechDev(std::string model_name, py_darray &params);
 
       std::tuple<std::vector<std::string>, py_darray, std::vector<bool>, std::vector<bool>>
       getHistoryInfo();
 
       void setup(double dt,
                  double tolerance,
-                 py_darray d_svec_kk_sm, // defRate,
-                 py_darray w_veccp_sm, // spin
-                 py_darray volRatio,
-                 py_darray eInt,
-                 py_darray stressSvecP,
-                 py_darray hist,
-                 double& tkelv);
+                 py_darray &d_svec_kk_sm, // defRate,
+                 py_darray &w_veccp_sm, // spin
+                 py_darray &volRatio,
+                 py_darray &eInt,
+                 py_darray &stressSvecP,
+                 py_darray &hist,
+                 double &tkelv);
       void computeRJ(py_darray &resid,
                      py_darray &J,
                      py_darray &x);
@@ -37,14 +67,13 @@ class ECMechPy
                     py_darray &eInt,
                     py_darray &stressSvecP,
                     py_darray &hist,
-                    double& tkelv,
+                    double &tkelv,
                     py_darray &sdd);
 
-      ~ECMechPy()
+      ~pyECMechDev()
       {
          delete model;
       }
 };
-
 
 #endif

--- a/pyecmech/ecmechpy.hpp
+++ b/pyecmech/ecmechpy.hpp
@@ -1,0 +1,52 @@
+#ifndef ECMECHPY_HPP
+#define ECMECHPY_HPP
+
+#include "ecmech_classes.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include<pybind11/numpy.h>
+
+typedef typename pybind11::array_t<double> py_darray;
+typedef typename pybind11::array_t<int32_t> py_iarray;
+
+class ECMechPy
+{
+   private:
+      pyevptn_base* model = nullptr;
+   public:
+      ECMechPy(std::string model_name, py_darray &params);
+
+      std::tuple<std::vector<std::string>, py_darray, std::vector<bool>, std::vector<bool>>
+      getHistInfo();
+
+      void setup(double dt,
+                 double tolerance,
+                 py_darray d_svec_kk_sm, // defRate,
+                 py_darray w_veccp_sm, // spin
+                 py_darray volRatio,
+                 py_darray eInt,
+                 py_darray stressSvecP,
+                 py_darray hist,
+                 double& tkelv,
+                 py_darray sdd,
+                 py_darray mtanSD);
+      void computeRJ(py_darray &resid,
+                     py_darray &J,
+                     py_darray &x);
+      
+      void getState(const py_darray &x,
+                    py_darray &eInt,
+                    py_darray &stressSvecP,
+                    py_darray &hist,
+                    double& tkelv,
+                    py_darray &sdd);
+
+      ~ECMechPy()
+      {
+         delete model;
+      }
+};
+
+
+#endif

--- a/pyecmech/ecmechpy.hpp
+++ b/pyecmech/ecmechpy.hpp
@@ -28,9 +28,7 @@ class ECMechPy
                  py_darray eInt,
                  py_darray stressSvecP,
                  py_darray hist,
-                 double& tkelv,
-                 py_darray sdd,
-                 py_darray mtanSD);
+                 double& tkelv);
       void computeRJ(py_darray &resid,
                      py_darray &J,
                      py_darray &x);

--- a/pyecmech/example-dev.py
+++ b/pyecmech/example-dev.py
@@ -1,0 +1,168 @@
+import ecmech as m
+import numpy as np
+from scipy.optimize import root
+
+assert m.__version__ == 'dev'
+
+# This file shows more how to use a developer set of tools to explore
+# the effects of different solvers or other features related to the
+# solve of a material point
+# It will be enabled by a cmake flag but currently that has not been added
+
+# Helper class for the root solve
+class ECMechProbDev:
+    def __init__(self, model_name, var):
+        self.myecmech = m.pyECMechDev(model_name, var)
+        # Find the number of history variables and store that for future use
+        names, vals, plot, state = self.myecmech.getHistoryInfo()
+        self.nhist = len(names)
+        self.ntvec = m.constants.ntvec
+        self.nsvec = m.constants.nsvec
+        self.nsvec2 = m.constants.nsvec2
+        self.nvr = m.constants.nvr
+        self.ne = m.constants.ne
+        self.nsvp = m.constants.nsvp
+        self.nwvec = m.constants.nwvec
+        self.nsdd = m.constants.nsdd
+
+    def solve(self, dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv):
+        '''
+            Solve does a per time step solve of the material update for all points inputted.
+            A few things to note:
+            d_svec_kk_sm has dimensions npts x self.nsvp input
+            w_veccp_sm has dimesnions npts x self.nwvec input
+            volRatio has dimensions npts x self.nvr input
+            eInt has dimensions npts x self.ne input/output
+            stressSvecP has dimensions npts x self.nsvec input/output
+            hist has dimensions npts x self.nhist input/output
+            tkelv has dimensions npts x 1 input/output
+            sdd has dimensions npts x self.nsdd output
+
+            If you pass in 1D arrays we will promote them to 2D arrays.
+        '''
+        d_svec_kk_sm = np.atleast_2d(d_svec_kk_sm)
+        w_veccp_sm = np.atleast_2d(w_veccp_sm)
+        volRatio = np.atleast_2d(volRatio)
+        eInt = np.atleast_2d(eInt)
+        stressSvecP = np.atleast_2d(stressSvecP)
+        hist = np.atleast_2d(hist)
+        tkelv = np.atleast_2d(tkelv)
+
+        npts = eInt.shape[0]
+        sdd = np.zeros((npts, self.nsdd))
+
+        x = np.zeros(8)
+
+        for i in range(npts):
+            x[:] = 0.0
+            self.setup(dt, tolerance, np.squeeze(d_svec_kk_sm[i, :]), np.squeeze(w_veccp_sm[i, :]), np.squeeze(volRatio[i, :]), np.squeeze(eInt[i, :]), np.squeeze(stressSvecP[i, :]), np.squeeze(hist[i, :]), np.squeeze(tkelv[i, :]))
+            sol = root(self.computeRJ, x, jac=True, method='hybr', tol=tolerance)
+            # If you want to check the success of the solver you can find that using
+            # sol.success
+            eInt[i, :], stressSvecP[i, :], hist[i, :], tkelv[i, :], sdd[i, :] = prob.getState(sol.x,  np.squeeze(eInt[i, :]), np.squeeze(stressSvecP[i, :]), np.squeeze(hist[i, :]), np.squeeze(tkelv[i, :]), np.squeeze(sdd[i, :]))
+
+        return (eInt, stressSvecP, hist, tkelv, sdd)
+
+    def getHistInfo(self):
+        names, vals, plot, state = self.myecmech.getHistoryInfo()
+        return (names, vals, plot, state)
+    def setup(self, dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv):
+        self.myecmech.setup(dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv)
+    def computeRJ(self, x):
+
+        ndim = x.shape[0]
+        resid = np.zeros(ndim)
+        jacob = np.zeros((ndim,ndim))
+        self.myecmech.computeRJ(resid, jacob, x)
+
+        return (resid, jacob)
+
+    def getState(self, x, eInt, stressSvecP, hist, tkelv, sdd):
+        self.myecmech.getState(x, eInt, stressSvecP, hist, tkelv, sdd)
+        return (eInt, stressSvecP, hist, tkelv, sdd)
+
+# Prints out function documentation of the module
+help(m.constants)
+help(m.pyECMechDev)
+
+# OFHC copper parameters
+# Taken from parameters in the ExaConstit test suite
+var = np.asarray([
+8.920e-6,
+0.003435984,
+1.0e-10,
+168.4e0,
+121.4e0,
+75.2e0,
+44.0e0,
+0.02e0,
+1.0e0,
+400.0e-3,
+17.0e-3,
+122.4e-3,
+0.0,
+5.0e9,
+17.0e-3,
+0.0,
+-1.0307952
+])
+
+prob = ECMechProb("voce_fcc_norm", var)
+
+# Our various input parameters
+dt = 0.1
+tolerance = 1e-10
+d_svec_kk_sm = np.zeros(7)
+# Just a simple monotonic tension example in the x direction
+d_tr = 1.0 / 3.0
+d_svec_kk_sm[0] = 1.0 - d_tr
+d_svec_kk_sm[1] = -d_tr
+d_svec_kk_sm[2] = -d_tr
+d_svec_kk_sm[6] = 3.0 * d_tr
+d_svec_kk_sm[:] *= 0.001
+
+stressSvecP = np.zeros(7)
+# This would control the spin of the problem if we wanted to 
+w_veccp_sm = np.zeros(3)
+eInt = np.zeros(1)
+volRatio = np.asarray([1.0, 1.0, 0.0, 0.0])
+
+volRatio[0] = volRatio[1]
+volRatio[1] = volRatio[0] * np.exp(d_svec_kk_sm[6] * dt)
+volRatio[3] = volRatio[1] - volRatio[0]
+volRatio[2] = volRatio[3] / (dt * 0.5 * (volRatio[0] + volRatio[1]))
+
+tkelv = 300.
+sdd = np.asarray([0, 0])
+mtanSD = np.zeros(36)
+
+histNames, histVals, histPlot, histState = prob.getHistInfo()
+
+# Just so we can see what the history names are
+print(histNames)
+
+hist = np.copy(histVals)
+hist_old = np.copy(hist)
+
+# An example of how to manually solve for things if you want to play around with different
+# solver options or if you just don't want to use the ECMechProb.solve() function
+x = np.zeros(8)
+prob.setup(dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv)
+sol = root(prob.computeRJ, x, jac=True, method='hybr', tol=tolerance)
+# If you want to check the success of the solver you can find that using
+# sol.success
+eInt, stressSvecP, hist, tkelv, sdd = prob.getState(sol.x, eInt, stressSvecP, hist, tkelv, sdd)
+
+# print(hist)
+# How to iterate over multiple time steps
+for i in range(40):
+    # This is pulled from how the test_px does things
+    volRatio[0] = volRatio[1]
+    volRatio[1] = volRatio[0] * np.exp(d_svec_kk_sm[6] * dt)
+    volRatio[3] = volRatio[1] - volRatio[0]
+    volRatio[2] = volRatio[3] / (dt * 0.5 * (volRatio[0] + volRatio[1]))
+    # An example of using the prob.solve() version of things rather than
+    # doing it by hand
+    eInt, stressSvecP, hist, tkelv, sdd = prob.solve(dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv)
+
+    print(stressSvecP)

--- a/pyecmech/example-dev.py
+++ b/pyecmech/example-dev.py
@@ -1,4 +1,4 @@
-import ecmech as m
+import pyecmech as m
 import numpy as np
 from scipy.optimize import root
 
@@ -82,8 +82,7 @@ class ECMechProbDev:
         return (eInt, stressSvecP, hist, tkelv, sdd)
 
 # Prints out function documentation of the module
-help(m.constants)
-help(m.pyECMechDev)
+# help(m)
 
 # OFHC copper parameters
 # Taken from parameters in the ExaConstit test suite
@@ -107,7 +106,7 @@ var = np.asarray([
 -1.0307952
 ])
 
-prob = ECMechProb("voce_fcc_norm", var)
+prob = ECMechProbDev("voce_fcc_norm", var)
 
 # Our various input parameters
 dt = 0.1
@@ -139,7 +138,7 @@ mtanSD = np.zeros(36)
 histNames, histVals, histPlot, histState = prob.getHistInfo()
 
 # Just so we can see what the history names are
-print(histNames)
+# print(histNames)
 
 hist = np.copy(histVals)
 hist_old = np.copy(hist)
@@ -152,7 +151,7 @@ sol = root(prob.computeRJ, x, jac=True, method='hybr', tol=tolerance)
 # If you want to check the success of the solver you can find that using
 # sol.success
 eInt, stressSvecP, hist, tkelv, sdd = prob.getState(sol.x, eInt, stressSvecP, hist, tkelv, sdd)
-
+print(stressSvecP[0])
 # print(hist)
 # How to iterate over multiple time steps
 for i in range(40):
@@ -165,4 +164,4 @@ for i in range(40):
     # doing it by hand
     eInt, stressSvecP, hist, tkelv, sdd = prob.solve(dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv)
 
-    print(stressSvecP)
+    print(stressSvecP[:,0])

--- a/pyecmech/example.py
+++ b/pyecmech/example.py
@@ -4,28 +4,109 @@ from scipy.optimize import root
 
 assert m.__version__ == 'dev'
 
-var = np.asarray([])
+# Helper class for the root solve
+class ECMechProb:
+    def __init__(self, model_name, var):
+        self.myecmech = m.ECMech(model_name, var)
 
-dt = 0.2
-d_svec_kk_sm = np.asarray([-0.0903958, 0.0275513, 0.0628445, 0.0277765, 0.0120316, 0.00948184, -0.00241654])
-stressSvecP = np.zeros(7) 
+    def getHistInfo(self):
+        names, vals, plot, state = self.myecmech.getHistoryInfo()
+        return (names, vals, plot, state)
+    def setup(self, dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv, sdd, mtanSD):
+        self.myecmech.setup(dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv, sdd, mtanSD)
+    def computeRJ(self, x):
+
+        ndim = x.shape[0]
+        resid = np.zeros(ndim)
+        jacob = np.zeros((ndim,ndim))
+        self.myecmech.computeRJ(resid, jacob, x)
+
+        return (resid, jacob)
+
+    def getState(self, x, eInt, stressSvecP, hist, tkelv, sdd):
+        self.myecmech.getState(x, eInt, stressSvecP, hist, tkelv, sdd)
+        return (eInt, stressSvecP, hist, tkelv, sdd)
+
+# Prints out function documentation of the module
+help(m.ECMech)
+
+# OFHC copper parameters
+# Taken from parameters in the ExaConstit test suite
+var = np.asarray([
+8.920e-6,
+0.003435984,
+1.0e-10,
+168.4e0,
+121.4e0,
+75.2e0,
+44.0e0,
+0.02e0,
+1.0e0,
+400.0e-3,
+17.0e-3,
+122.4e-3,
+0.0,
+5.0e9,
+17.0e-3,
+0.0,
+-1.0307952
+])
+
+prob = ECMechProb("voce_fcc_norm", var)
+
+# Our various input parameters
+dt = 0.1
+tolerance = 1e-10
+d_svec_kk_sm = np.zeros(7)
+# Just a simple monotonic tension example in the x direction
+d_tr = 1.0 / 3.0
+d_svec_kk_sm[0] = 1.0 - d_tr
+d_svec_kk_sm[1] = -d_tr
+d_svec_kk_sm[2] = -d_tr
+d_svec_kk_sm[6] = 3.0 * d_tr
+d_svec_kk_sm[:] *= 0.001
+
+stressSvecP = np.zeros(7)
+# This would control the spin of the problem if we wanted to 
 w_veccp_sm = np.zeros(3)
 eInt = np.zeros(1)
 volRatio = np.asarray([1.0, 1.0, 0.0, 0.0])
-hist = np.asarray([])
+
+volRatio[0] = volRatio[1]
+volRatio[1] = volRatio[0] * np.exp(d_svec_kk_sm[6] * dt)
+volRatio[3] = volRatio[1] - volRatio[0]
+volRatio[2] = volRatio[3] / (dt * 0.5 * (volRatio[0] + volRatio[1]))
+
+tkelv = 300.
+sdd = np.asarray([0, 0])
+mtanSD = np.zeros(36)
+
+histNames, histVals, histPlot, histState = prob.getHistInfo()
+
+# Just so we can see what the history names are
+print(histNames)
+
+hist = np.copy(histVals)
 hist_old = np.copy(hist)
 
 x = np.zeros(8)
 
-prob = ECMechProb("voce_fcc_norm", var)
 prob.setup(dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv, sdd, mtanSD)
-
-sol = root(prob.computeRJ, x, jac=True, method='hybr', tol=1e-10)
+sol = root(prob.computeRJ, x, jac=True, method='hybr', tol=tolerance)
+# If you want to check the success of the solver you can find that using
+# sol.success
 eInt, stressSvecP, hist, tkelv, sdd = prob.getState(sol.x, eInt, stressSvecP, hist, tkelv, sdd)
 
 # print(hist)
 # How to iterate over multiple time steps
-for i in range(20):
+for i in range(40):
+    # This is pulled from how the test_px does things
+    volRatio[0] = volRatio[1]
+    volRatio[1] = volRatio[0] * np.exp(d_svec_kk_sm[6] * dt)
+    volRatio[3] = volRatio[1] - volRatio[0]
+    volRatio[2] = volRatio[3] / (dt * 0.5 * (volRatio[0] + volRatio[1]))
+    # Set this to 0 before each root solve
+    x[:] = 0.0
     prob.setup(dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv, sdd, mtanSD)
-    sol = root(prob.computeRJ, x, jac=True, method='hybr', tol=1e-10)
+    sol = root(prob.computeRJ, x, jac=True, method='hybr', tol=tolerance)
     eInt, stressSvecP, hist, tkelv, sdd = prob.getState(sol.x, eInt, stressSvecP, hist, tkelv, sdd)

--- a/pyecmech/example.py
+++ b/pyecmech/example.py
@@ -1,0 +1,31 @@
+import ecmech as m
+import numpy as np
+from scipy.optimize import root
+
+assert m.__version__ == 'dev'
+
+var = np.asarray([])
+
+dt = 0.2
+d_svec_kk_sm = np.asarray([-0.0903958, 0.0275513, 0.0628445, 0.0277765, 0.0120316, 0.00948184, -0.00241654])
+stressSvecP = np.zeros(7) 
+w_veccp_sm = np.zeros(3)
+eInt = np.zeros(1)
+volRatio = np.asarray([1.0, 1.0, 0.0, 0.0])
+hist = np.asarray([])
+hist_old = np.copy(hist)
+
+x = np.zeros(8)
+
+prob = ECMechProb("voce_fcc_norm", var)
+prob.setup(dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv, sdd, mtanSD)
+
+sol = root(prob.computeRJ, x, jac=True, method='hybr', tol=1e-10)
+eInt, stressSvecP, hist, tkelv, sdd = prob.getState(sol.x, eInt, stressSvecP, hist, tkelv, sdd)
+
+# print(hist)
+# How to iterate over multiple time steps
+for i in range(20):
+    prob.setup(dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv, sdd, mtanSD)
+    sol = root(prob.computeRJ, x, jac=True, method='hybr', tol=1e-10)
+    eInt, stressSvecP, hist, tkelv, sdd = prob.getState(sol.x, eInt, stressSvecP, hist, tkelv, sdd)

--- a/pyecmech/example.py
+++ b/pyecmech/example.py
@@ -1,27 +1,29 @@
 import ecmech as m
 import numpy as np
-from scipy.optimize import root
 
 assert m.__version__ == 'dev'
 
-# Helper class for the root solve
+
+# Helper class for things
 class ECMechProb:
     def __init__(self, model_name, var):
-        self.myecmech = m.ECMech(model_name, var)
+        self.myecmech = m.pyECMech(model_name, var)
         # Find the number of history variables and store that for future use
-        names, vals, plot, state = self.myecmech.getHistoryInfo()
-        self.nhist = len(names)
-        # Maybe have these provided by myecmech?
-        self.ntvec = 5
-        self.nsvec = 6
-        self.nsvec2 = 36
-        self.nvr = 4
-        self.ne = 1
-        self.nsvp = 7
-        self.nwvec = 3
-        self.nsdd = 2
+        self.nhist = self.myecmech.getNumberHistory()
+        self.ntvec = m.constants.ntvec
+        self.nsvec = m.constants.nsvec
+        self.nsvec2 = m.constants.nsvec2
+        self.nvr = m.constants.nvr
+        self.ne = m.constants.ne
+        self.nsvp = m.constants.nsvp
+        self.nwvec = m.constants.nwvec
+        self.nsdd = m.constants.nsdd
 
-    def solve(self, dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv):
+    def getHistInfo(self):
+        names, vals, plot, state = self.myecmech.getHistoryInfo()
+        return (names, vals, plot, state)
+
+    def solve(self, dt, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv):
         '''
             Solve does a per time step solve of the material update for all points inputted.
             A few things to note:
@@ -36,6 +38,7 @@ class ECMechProb:
 
             If you pass in 1D arrays we will promote them to 2D arrays.
         '''
+
         d_svec_kk_sm = np.atleast_2d(d_svec_kk_sm)
         w_veccp_sm = np.atleast_2d(w_veccp_sm)
         volRatio = np.atleast_2d(volRatio)
@@ -46,39 +49,12 @@ class ECMechProb:
 
         npts = eInt.shape[0]
         sdd = np.zeros((npts, self.nsdd))
-
-        x = np.zeros(8)
-
-        for i in range(npts):
-            x[:] = 0.0
-            self.setup(dt, tolerance, np.squeeze(d_svec_kk_sm[i, :]), np.squeeze(w_veccp_sm[i, :]), np.squeeze(volRatio[i, :]), np.squeeze(eInt[i, :]), np.squeeze(stressSvecP[i, :]), np.squeeze(hist[i, :]), np.squeeze(tkelv[i, :]))
-            sol = root(self.computeRJ, x, jac=True, method='hybr', tol=tolerance)
-            # If you want to check the success of the solver you can find that using
-            # sol.success
-            eInt[i, :], stressSvecP[i, :], hist[i, :], tkelv[i, :], sdd[i, :] = prob.getState(sol.x,  np.squeeze(eInt[i, :]), np.squeeze(stressSvecP[i, :]), np.squeeze(hist[i, :]), np.squeeze(tkelv[i, :]), np.squeeze(sdd[i, :]))
-
-        return (eInt, stressSvecP, hist, tkelv, sdd)
-
-    def getHistInfo(self):
-        names, vals, plot, state = self.myecmech.getHistoryInfo()
-        return (names, vals, plot, state)
-    def setup(self, dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv):
-        self.myecmech.setup(dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv)
-    def computeRJ(self, x):
-
-        ndim = x.shape[0]
-        resid = np.zeros(ndim)
-        jacob = np.zeros((ndim,ndim))
-        self.myecmech.computeRJ(resid, jacob, x)
-
-        return (resid, jacob)
-
-    def getState(self, x, eInt, stressSvecP, hist, tkelv, sdd):
-        self.myecmech.getState(x, eInt, stressSvecP, hist, tkelv, sdd)
+        self.myecmech.solve(dt, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv, sdd, npts)
         return (eInt, stressSvecP, hist, tkelv, sdd)
 
 # Prints out function documentation of the module
-# help(m.ECMech)
+# help(m.constants)
+# help(m.pyECMech)
 
 # OFHC copper parameters
 # Taken from parameters in the ExaConstit test suite
@@ -104,7 +80,7 @@ var = np.asarray([
 
 prob = ECMechProb("voce_fcc_norm", var)
 
-# Our various input parameters
+# # Our various input parameters
 dt = 0.1
 tolerance = 1e-10
 d_svec_kk_sm = np.zeros(7)
@@ -122,42 +98,26 @@ w_veccp_sm = np.zeros(3)
 eInt = np.zeros(1)
 volRatio = np.asarray([1.0, 1.0, 0.0, 0.0])
 
-volRatio[0] = volRatio[1]
-volRatio[1] = volRatio[0] * np.exp(d_svec_kk_sm[6] * dt)
-volRatio[3] = volRatio[1] - volRatio[0]
-volRatio[2] = volRatio[3] / (dt * 0.5 * (volRatio[0] + volRatio[1]))
-
 tkelv = 300.
 sdd = np.asarray([0, 0])
 mtanSD = np.zeros(36)
 
 histNames, histVals, histPlot, histState = prob.getHistInfo()
 
-# Just so we can see what the history names are
+# # Just so we can see what the history names are
 print(histNames)
 
 hist = np.copy(histVals)
-hist_old = np.copy(hist)
-
-# An example of how to manually solve for things if you want to play around with different
-# solver options or if you just don't want to use the ECMechProb.solve() function
-x = np.zeros(8)
-prob.setup(dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv)
-sol = root(prob.computeRJ, x, jac=True, method='hybr', tol=tolerance)
-# If you want to check the success of the solver you can find that using
-# sol.success
-eInt, stressSvecP, hist, tkelv, sdd = prob.getState(sol.x, eInt, stressSvecP, hist, tkelv, sdd)
-
-# print(hist)
+print(hist)
 # How to iterate over multiple time steps
-for i in range(40):
+for i in range(41):
+    # An example of using the prob.solve() version of things rather than
+    # doing it by hand
+    eInt, stressSvecP, hist, tkelv, sdd = prob.solve(dt, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv)
     # This is pulled from how the test_px does things
     volRatio[0] = volRatio[1]
     volRatio[1] = volRatio[0] * np.exp(d_svec_kk_sm[6] * dt)
     volRatio[3] = volRatio[1] - volRatio[0]
     volRatio[2] = volRatio[3] / (dt * 0.5 * (volRatio[0] + volRatio[1]))
-    # An example of using the prob.solve() version of things rather than
-    # doing it by hand
-    eInt, stressSvecP, hist, tkelv, sdd = prob.solve(dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv)
 
-    print(stressSvecP)
+    print(stressSvecP[:,0])

--- a/pyecmech/example.py
+++ b/pyecmech/example.py
@@ -8,12 +8,62 @@ assert m.__version__ == 'dev'
 class ECMechProb:
     def __init__(self, model_name, var):
         self.myecmech = m.ECMech(model_name, var)
+        # Find the number of history variables and store that for future use
+        names, vals, plot, state = self.myecmech.getHistoryInfo()
+        self.nhist = len(names)
+        # Maybe have these provided by myecmech?
+        self.ntvec = 5
+        self.nsvec = 6
+        self.nsvec2 = 36
+        self.nvr = 4
+        self.ne = 1
+        self.nsvp = 7
+        self.nwvec = 3
+        self.nsdd = 2
+
+    def solve(self, dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv):
+        '''
+            Solve does a per time step solve of the material update for all points inputted.
+            A few things to note:
+            d_svec_kk_sm has dimensions npts x self.nsvp input
+            w_veccp_sm has dimesnions npts x self.nwvec input
+            volRatio has dimensions npts x self.nvr input
+            eInt has dimensions npts x self.ne input/output
+            stressSvecP has dimensions npts x self.nsvec input/output
+            hist has dimensions npts x self.nhist input/output
+            tkelv has dimensions npts x 1 input/output
+            sdd has dimensions npts x self.nsdd output
+
+            If you pass in 1D arrays we will promote them to 2D arrays.
+        '''
+        d_svec_kk_sm = np.atleast_2d(d_svec_kk_sm)
+        w_veccp_sm = np.atleast_2d(w_veccp_sm)
+        volRatio = np.atleast_2d(volRatio)
+        eInt = np.atleast_2d(eInt)
+        stressSvecP = np.atleast_2d(stressSvecP)
+        hist = np.atleast_2d(hist)
+        tkelv = np.atleast_2d(tkelv)
+
+        npts = eInt.shape[0]
+        sdd = np.zeros((npts, self.nsdd))
+
+        x = np.zeros(8)
+
+        for i in range(npts):
+            x[:] = 0.0
+            self.setup(dt, tolerance, np.squeeze(d_svec_kk_sm[i, :]), np.squeeze(w_veccp_sm[i, :]), np.squeeze(volRatio[i, :]), np.squeeze(eInt[i, :]), np.squeeze(stressSvecP[i, :]), np.squeeze(hist[i, :]), np.squeeze(tkelv[i, :]))
+            sol = root(self.computeRJ, x, jac=True, method='hybr', tol=tolerance)
+            # If you want to check the success of the solver you can find that using
+            # sol.success
+            eInt[i, :], stressSvecP[i, :], hist[i, :], tkelv[i, :], sdd[i, :] = prob.getState(sol.x,  np.squeeze(eInt[i, :]), np.squeeze(stressSvecP[i, :]), np.squeeze(hist[i, :]), np.squeeze(tkelv[i, :]), np.squeeze(sdd[i, :]))
+
+        return (eInt, stressSvecP, hist, tkelv, sdd)
 
     def getHistInfo(self):
         names, vals, plot, state = self.myecmech.getHistoryInfo()
         return (names, vals, plot, state)
-    def setup(self, dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv, sdd, mtanSD):
-        self.myecmech.setup(dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv, sdd, mtanSD)
+    def setup(self, dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv):
+        self.myecmech.setup(dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv)
     def computeRJ(self, x):
 
         ndim = x.shape[0]
@@ -28,7 +78,7 @@ class ECMechProb:
         return (eInt, stressSvecP, hist, tkelv, sdd)
 
 # Prints out function documentation of the module
-help(m.ECMech)
+# help(m.ECMech)
 
 # OFHC copper parameters
 # Taken from parameters in the ExaConstit test suite
@@ -89,9 +139,10 @@ print(histNames)
 hist = np.copy(histVals)
 hist_old = np.copy(hist)
 
+# An example of how to manually solve for things if you want to play around with different
+# solver options or if you just don't want to use the ECMechProb.solve() function
 x = np.zeros(8)
-
-prob.setup(dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv, sdd, mtanSD)
+prob.setup(dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv)
 sol = root(prob.computeRJ, x, jac=True, method='hybr', tol=tolerance)
 # If you want to check the success of the solver you can find that using
 # sol.success
@@ -105,8 +156,8 @@ for i in range(40):
     volRatio[1] = volRatio[0] * np.exp(d_svec_kk_sm[6] * dt)
     volRatio[3] = volRatio[1] - volRatio[0]
     volRatio[2] = volRatio[3] / (dt * 0.5 * (volRatio[0] + volRatio[1]))
-    # Set this to 0 before each root solve
-    x[:] = 0.0
-    prob.setup(dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv, sdd, mtanSD)
-    sol = root(prob.computeRJ, x, jac=True, method='hybr', tol=tolerance)
-    eInt, stressSvecP, hist, tkelv, sdd = prob.getState(sol.x, eInt, stressSvecP, hist, tkelv, sdd)
+    # An example of using the prob.solve() version of things rather than
+    # doing it by hand
+    eInt, stressSvecP, hist, tkelv, sdd = prob.solve(dt, tolerance, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv)
+
+    print(stressSvecP)

--- a/pyecmech/example.py
+++ b/pyecmech/example.py
@@ -1,4 +1,4 @@
-import ecmech as m
+import pyecmech as m
 import numpy as np
 
 assert m.__version__ == 'dev'
@@ -53,8 +53,7 @@ class ECMechProb:
         return (eInt, stressSvecP, hist, tkelv, sdd)
 
 # Prints out function documentation of the module
-# help(m.constants)
-# help(m.pyECMech)
+# help(m)
 
 # OFHC copper parameters
 # Taken from parameters in the ExaConstit test suite
@@ -104,20 +103,20 @@ mtanSD = np.zeros(36)
 
 histNames, histVals, histPlot, histState = prob.getHistInfo()
 
-# # Just so we can see what the history names are
-print(histNames)
+# Just so we can see what the history names and values are
+# print(histNames)
+# print(histVals)
 
 hist = np.copy(histVals)
-print(hist)
 # How to iterate over multiple time steps
 for i in range(41):
-    # An example of using the prob.solve() version of things rather than
-    # doing it by hand
-    eInt, stressSvecP, hist, tkelv, sdd = prob.solve(dt, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv)
     # This is pulled from how the test_px does things
     volRatio[0] = volRatio[1]
     volRatio[1] = volRatio[0] * np.exp(d_svec_kk_sm[6] * dt)
     volRatio[3] = volRatio[1] - volRatio[0]
     volRatio[2] = volRatio[3] / (dt * 0.5 * (volRatio[0] + volRatio[1]))
+
+    # An example of using prob.solve()
+    eInt, stressSvecP, hist, tkelv, sdd = prob.solve(dt, d_svec_kk_sm, w_veccp_sm, volRatio, eInt, stressSvecP, hist, tkelv)
 
     print(stressSvecP[:,0])

--- a/src/ecmech/ECMech_config.h.in
+++ b/src/ecmech/ECMech_config.h.in
@@ -5,3 +5,5 @@
 #cmakedefine HAVE_ECMECH
 #cmakedefine ECMECH_USE_DPEFF
 #cmakedefine ECMECH_DEBUG
+#cmakedefine ECMECH_PY
+#cmakedefine ECMECH_PYDEV


### PR DESCRIPTION
I've created an initial set of python bindings that covers most of the material models in the library. These bindings would allow someone to run things like evptn through python with the one difference being that we can make use of solvers from the scipy optimize library instead of SNLS. I found this useful to investigate some models I've been working on and where I needed to explore the effects of different solvers in something other than full blow C++. Since, I found my initial hack together pretty useful I figured I clean it up a bit for other people to make use of.

In order to create the bindings, I make use of [pybind11 v2.7.1](https://pybind11.readthedocs.io/en/stable/index.html) which I've included as a new submodule within the library.

I still need to improve on some of the python binding documentation but this should allow people to at least start playing around with things. Also, I could probably expand on the python example and actually make one of the classes in there more flexible, so it's easier to run multiple points at a time.