### PR TITLE
HCP model fixes

### DIFF
--- a/cmake/CMakeBasics.cmake
+++ b/cmake/CMakeBasics.cmake
@@ -5,7 +5,7 @@ set(PACKAGE_BUGREPORT "carson16@llnl.gov")
 
 set(ECMech_VERSION_MAJOR 0)
 set(ECMech_VERSION_MINOR 4)
-set(ECMech_VERSION_PATCH \"1\")
+set(ECMech_VERSION_PATCH \"2\")
 
 set(ECMECH_HEADER_INCLUDE_DIR
     ${PROJECT_BINARY_DIR}/include/ecmech

--- a/src/ecmech/ECMech_elastic.h
+++ b/src/ecmech/ECMech_elastic.h
@@ -257,7 +257,7 @@ namespace evptn {
             m_K_diag[3] = two * m_c44;
             m_K_diag[4] = two * m_c44;
             double K_vecds_s = twothird * m_c11 + twothird * m_c12 + fourthirds * m_c13 + m_c33 * onethird;
-            m_K_sdax3 = -sqr2 * (-m_c11 - m_c12 + m_c13 + m_c33) * onethird;
+            m_K_sdax3 = sqr2 * (-m_c11 - m_c12 + m_c13 + m_c33) * onethird;
             m_bulk_modulus = onethird * K_vecds_s;
             //
             // m_shear_modulus below ignores the m_K_sdax3 contribution, but it is just meant to be approximate anyway

--- a/src/ecmech/ECMech_elastic.h
+++ b/src/ecmech/ECMech_elastic.h
@@ -257,7 +257,7 @@ namespace evptn {
             m_K_diag[3] = two * m_c44;
             m_K_diag[4] = two * m_c44;
             double K_vecds_s = twothird * m_c11 + twothird * m_c12 + fourthirds * m_c13 + m_c33 * onethird;
-            m_K_sdax3 = sqr2 * (-m_c11 - m_c12 + m_c13 + m_c33) * onethird;
+            m_K_sdax3 = -sqr2 * (-m_c11 - m_c12 + m_c13 + m_c33) * onethird;
             m_bulk_modulus = onethird * K_vecds_s;
             //
             // m_shear_modulus below ignores the m_K_sdax3 contribution, but it is just meant to be approximate anyway
@@ -352,21 +352,28 @@ namespace evptn {
             for (int iTvec = 0; iTvec < ecmech::ntvec; ++iTvec) {
                 double vFact = inv_det_v_e * inv_a_vol * m_K_diag[iTvec];
                 for (int jTvec = 0; jTvec < ecmech::ntvec; ++jTvec) {
-                    M6[ECMECH_NN_INDX(iTvec, jTvec, ecmech::nsvec)] = vFact * A[ECMECH_NN_INDX(iTvec, jTvec, ecmech::ntvec)];
+                    M6[ECMECH_NN_INDX(iTvec, jTvec, ecmech::nsvec)] = vFact * A[ECMECH_NM_INDX(iTvec, jTvec, N, M)];
                 }
             }
 
             // M6[iSvecS,:] = dsigC_de[iSvecS, iTvecHex] * A[iTvecHex,:] // for hexagonal specifically
             // dsigC_de[iTvecHex, iSvecS] does not end up getting used
+            for (int iSvec = 0; iSvec < ecmech::nsvec; ++iSvec) {
+                M6[ECMECH_NN_INDX(iSvec, iSvecS, ecmech::nsvec)] = 0.0;
+                M6[ECMECH_NN_INDX(iSvecS, iSvec, ecmech::nsvec)] = 0.0;
+            }
+
             {
                 double vFact = inv_det_v_e * inv_a_vol * m_K_sdax3;
                 for (int jTvec = 0; jTvec < ecmech::ntvec; ++jTvec) {
-                    M6[ECMECH_NN_INDX(iSvecS, jTvec, ecmech::nsvec)] = vFact * A[ECMECH_NN_INDX(iTvecHex, jTvec, ecmech::ntvec)];
+                    M6[ECMECH_NN_INDX(iSvecS, jTvec, ecmech::nsvec)] = vFact * A[ECMECH_NM_INDX(iTvecHex, jTvec, N, M)];
                 }
             }
-
-            for (int iSvec = 0; iSvec < ecmech::nsvec; ++iSvec) {
-                M6[ECMECH_NN_INDX(iSvec, iSvecS, ecmech::nsvec)] = 0.0;
+            {
+                double vFact = inv_det_v_e * inv_a_vol * m_K_sdax3;
+                for (int jTvec = 0; jTvec < ecmech::ntvec; ++jTvec) {
+                    M6[ECMECH_NN_INDX(jTvec, iSvecS, ecmech::nsvec)] = vFact * A[ECMECH_NM_INDX(iTvecHex, jTvec, N, M)];
+                }
             }
         }
 

--- a/src/ecmech/ECMech_util.h
+++ b/src/ecmech/ECMech_util.h
@@ -15,7 +15,6 @@
 #endif
 
 #include "RAJA/RAJA.hpp"
-#include "SNLS_linalg.h"
 
 //
 // maybe replace this macro with RAJA::View machinery at some point

--- a/src/ecmech/ECMech_util.h
+++ b/src/ecmech/ECMech_util.h
@@ -15,6 +15,7 @@
 #endif
 
 #include "RAJA/RAJA.hpp"
+#include "SNLS_linalg.h"
 
 //
 // maybe replace this macro with RAJA::View machinery at some point

--- a/src/ecmech/kinetics/ECMech_kinetics_KMBalD.h
+++ b/src/ecmech/kinetics/ECMech_kinetics_KMBalD.h
@@ -255,7 +255,7 @@ namespace ecmech {
          double
          getFixedRefRate(const double* const vals) const
          {
-            return 1.0 / (1.0 / vals[0] + 1.0 / vals[1]); // _gam_w + _gam_r ;
+            return 1.0 / (1.0 / vals[0] + 1.0 / vals[1]);
          }
 
          /**

--- a/src/ecmech/kinetics/ECMech_kinetics_KMBalD.h
+++ b/src/ecmech/kinetics/ECMech_kinetics_KMBalD.h
@@ -255,7 +255,7 @@ namespace ecmech {
          double
          getFixedRefRate(const double* const vals) const
          {
-            return vals[0] + vals[1]; // _gam_w + _gam_r ;
+            return 1.0 / (1.0 / vals[0] + 1.0 / vals[1]); // _gam_w + _gam_r ;
          }
 
          /**

--- a/test/test_px.cxx
+++ b/test/test_px.cxx
@@ -160,7 +160,7 @@ TEST(ecmech, px_a)
    }
 
 #if KIN_TYPE
-   EXPECT_LT(fabs(sAvg - 0.00816346240674), 1e-10) << "Did not get expected value";
+   EXPECT_LT(fabs(sAvg - 0.00816331652264), 1e-10) << "Did not get expected value";
 #else
    EXPECT_LT(fabs(sAvg - 0.00344825801180), 1e-10) << "Did not get expected value";
 #endif

--- a/test/test_updst.cxx
+++ b/test/test_updst.cxx
@@ -257,11 +257,11 @@ TEST(ecmech, driver_a)
    }
 
 #if KIN_TYPE && !(DO_FD_CHECK_MTAN)
-   EXPECT_LT(fabs(cauchy_stress_d6p[2] - 0.006664661118275), 1e-10) <<
+   EXPECT_LT(fabs(cauchy_stress_d6p[2] - 0.006664208062085), 1e-10) <<
       "Did not get expected value for stress component";
-   EXPECT_LT(fabs(hist[ecmech::evptn::iHistLbH + 0] - 88.61845050083), 1e-8) <<
+   EXPECT_LT(fabs(hist[ecmech::evptn::iHistLbH + 0] - 87.96284116155), 1e-8) <<
       "Did not get expected value for history variable";
-   EXPECT_LT(fabs(cauchy_stress_d6p[iSvecP] - 0.00332602112947), 1e-10) <<
+   EXPECT_LT(fabs(cauchy_stress_d6p[iSvecP] - 0.00332519207297), 1e-10) <<
       "Did not get expected value for stress component";
 #endif
 


### PR DESCRIPTION
Some small fixes to get the HCP models up and running.

When running an HCP model in ExaConstit, I wasn't able to get things to converge at all and it appeared to be an issue with the material tangent stiffness calculation. I was able to track this down to a few small issues in the elastic model of the HCP model. One of them was that it appeared that the `M6[iSvecS,:] = dsigC_de[iSvecS, iTvecHex] * A[iTvecHex,:]` term actually needed to be symmetric and then that the `m_K_sdax3` term was missing a minus sign. Both of these I noticed after looking up some of the original formulations in Nathan's thesis work as it had the full transformation matrix defined.

Outside of this, I noticed the KMBalDD could use a more stable form for the fixed reference rate calculation. Since, if you have super large differences in the reference rates then that drive the implicit calculations to be wrong. So, I swapped over to the geometric mean which appears to have made things stable. Did result in some minor changes of the KMBalDD tests but they all seemed reasonable given we are changing the value of the fixed ref rate.